### PR TITLE
Fixed S3 bucket policy to make it canonical

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,8 @@ resource "aws_alb" "main" {
 
 data "aws_iam_policy_document" "bucket_policy" {
   statement {
+    sid = "AllowToPutLoadBalancerLogsToS3Bucket"
+
     actions = [
       "s3:PutObject",
     ]
@@ -31,7 +33,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${data.aws_elb_service_account.main.id}"]
+      identifiers = ["arn:aws:iam::${data.aws_elb_service_account.main.id}:root"]
     }
   }
 }

--- a/test/integration/default/local_alb.rb
+++ b/test/integration/default/local_alb.rb
@@ -43,7 +43,7 @@ describe s3_bucket(log_bucket) do
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "",
+            "Sid": "AllowToPutLoadBalancerLogsToS3Bucket",
             "Effect": "Allow",
             "Principal": {
                 "AWS": "arn:aws:iam::#{principal_account_id}:root"


### PR DESCRIPTION
This PR fixes `~ module.alb.aws_s3_bucket.log_bucket` which happens every time I run plan.