### PR TITLE
Alb listener outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "alb_id" {
   value       = "${aws_alb.main.id}"
 }
 
+output "alb_listener_https_id" {
+  description = "The ID of the ALB Listener we created."
+  value       = "${aws_alb_listener.frontend_https.id"
+}
+
 output "alb_zone_id" {
   description = "The zone_id of the ALB to assist with creating DNS records."
   value       = "${aws_alb.main.zone_id}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "alb_id" {
 
 output "alb_listener_https_id" {
   description = "The ID of the ALB Listener we created."
-  value       = "${aws_alb_listener.frontend_https.id"
+  value       = "${aws_alb_listener.frontend_https.id}"
 }
 
 output "alb_zone_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "alb_listener_https_id" {
   value       = "${aws_alb_listener.frontend_https.id}"
 }
 
+output "alb_listener_http_id" {
+  description = "The ID of the ALB Listener we created."
+  value       = "${aws_alb_listener.frontend_http.id}"
+}
+
 output "alb_zone_id" {
   description = "The zone_id of the ALB to assist with creating DNS records."
   value       = "${aws_alb.main.zone_id}"


### PR DESCRIPTION
This is useful if you plan to use ALB with ECS. 
I'm using ECS to host my apps and ALB is in front. When using aws_alb_listener_rule for path-based routing it requires alb_listener_arn.
I'm not sure if it is possible to export only HTTP or HTTPS based on which one is actually used?