### PR TITLE
Possible fix for Terraform v0.11(output to non-existing resource)

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,12 +10,12 @@ output "alb_id" {
 
 output "alb_listener_https_id" {
   description = "The ID of the ALB Listener we created."
-  value       = "${aws_alb_listener.frontend_https.id}"
+  value       = "${element(concat(aws_alb_listener.frontend_https.*.id, list("")), 0)}"
 }
 
 output "alb_listener_http_id" {
   description = "The ID of the ALB Listener we created."
-  value       = "${aws_alb_listener.frontend_http.id}"
+  value       = "${element(concat(aws_alb_listener.frontend_http.*.id, list("")), 0)}"
 }
 
 output "alb_zone_id" {


### PR DESCRIPTION
With v0.11 Terraform now checks outputs for errors so as not to propagate them through modules etc and help in debugging. This seems to fix the error when using only HTTP or HTTPS listener.
More here (near the bottom):
https://www.terraform.io/upgrade-guides/0-11.html 