### PR TITLE
Add ARN of ALB to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "target_group_arn" {
   description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
   value       = "${aws_alb_target_group.target_group.arn}"
 }
+
+output "alb_arn" {
+  description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
+  value       = "${aws_alb.main.arn}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,6 @@ output "target_group_arn" {
 }
 
 output "alb_arn" {
-  description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
+  description = "ARN of the ALB itself. Useful for debug output, for example when attaching a WAF."
   value       = "${aws_alb.main.arn}"
 }


### PR DESCRIPTION
In some cases, it can be desirable to have access to the ALB ARN. One example of this is if you want to attach a WAF to it. 
