### PR TITLE
Adding the health check code for ALB health checking

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ resource "aws_alb_target_group" "target_group" {
     unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
     timeout             = "${var.health_check_timeout}"
     protocol            = "${var.backend_protocol}"
+    matcher             = "${var.health_check_code}"
   }
 
   stickiness {

--- a/test/integration/default/local_alb.rb
+++ b/test/integration/default/local_alb.rb
@@ -33,6 +33,7 @@ describe alb_target_group('my-alb-tg') do
     its(:health_check_path) { should eq '/' }
     its(:health_check_port) { should eq 'traffic-port' }
     its(:health_check_protocol) { should eq 'HTTP' }
+    its(:health_check_code) { should eq '200-299' }
     it { should belong_to_alb('my-alb') }
     it { should belong_to_vpc('my-vpc') }
  end

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,11 @@ variable "health_check_unhealthy_threshold" {
   default     = 3
 }
 
+variable "health_check_code" {
+  description = "The HTTP codes that are a success when checking TG health"
+  default     = "200-299"
+}
+
 variable "create_log_bucket" {
   description = "Create the S3 bucket (named with the log_bucket_name var) and attach a policy to allow ALB logging."
   default     = false


### PR DESCRIPTION
I'm using ALB as a front for Jenkins and usually it responds 403 on / so having a possiblity to change the expected HTTP code seems fine.