### PR TITLE
move to kitchen-terraform 3.0.x and terraform 0.11.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: "terraform"
-  directory: "examples/test_fixtures"
+  root_module_directory: "examples/test_fixtures"
 
 provisioner:
   name: "terraform"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ script:
   - terraform validate
   - cd -
   - terraform -v
+  - chef gem list
   - kitchen test --destroy always
 
 # after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 
 before_script:
   - echo 'before_script'
-  # Get a random variable from the awscli and use it through the remainder of the test cycle.
+  # Get a random region from the awscli and use it through the remainder of the test cycle.
   - export AWS_REGION=$(docker run --env AWS_DEFAULT_REGION=us-east-2 --env AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --env AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} garland/aws-cli-docker aws ec2 describe-regions --query 'Regions[].{Name:RegionName}' --output text | shuf | head -n1)
   - echo "using AWS_REGION=${AWS_REGION}"
   - export TF_VAR_region=${AWS_REGION}
@@ -33,13 +33,13 @@ before_script:
   - mv terraform ${HOME}/bin/
   - rm -f terraform.zip
   - terraform -v
-  - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
-  - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
-  - chef gem install bundler
-  - chef gem install kitchen-terraform
-  # seems fragile. How to call 
-  - ~/.chefdk/gem/ruby/2.4.0/bin/bundle install
-  - chef gem list
+  # - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
+  # - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
+  # - chef gem install bundler
+  # - chef gem install kitchen-terraform
+  # seems fragile. How to call? 
+  # - ~/.chefdk/gem/ruby/2.4.0/bin/bundle install
+  # - chef gem list
 
 script:
   - echo 'script'
@@ -55,33 +55,16 @@ script:
   - terraform -v
   - bundle exec kitchen test --destroy always
 
-# after_success:
-#   - echo 'after_success'
-
-# after_failure:
-#   - echo 'after_failure'
-
-before_deploy:
-# check if this is new release and conditionally continue?
-  - echo 'before_deploy phase'
-
 deploy:
-# likely want to publish to the registry
+# publish to the registry when those APIs are documented
   provider: script
   script: ci/deploy.sh
   on:
-    branch: dev
-
-# after_deploy:
-# notify of success/failure provide links
-#   - echo 'after_deploy'
-
-# after_script:
-#   - echo 'after_script'
+    branch: master
 
 notifications:
   email:
     recipients:
       - brandon@atscale.run
-    on_success: change # default: change
-    on_failure: change # default: always
+    on_success: change
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ before_script:
   - echo "using AWS_REGION=${AWS_REGION}"
   - export TF_VAR_region=${AWS_REGION}
   - curl --output terraform.zip https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_linux_amd64.zip
-  - "sha256sum terraform.zip | grep \"402b4333792967986383670134bb52a8948115f83ab6bda35f57fa2c3c9e9279\""
-  - unzip terraform.zip -d terraform
+  - sha256sum terraform.zip  | grep "402b4333792967986383670134bb52a8948115f83ab6bda35f57fa2c3c9e9279" -q
+  - unzip terraform.zip
   - chmod +x terraform
   - mkdir -p ${HOME}/bin
   - export PATH=${PATH}:${HOME}/bin
   - mv terraform ${HOME}/bin/
-  - rm -f terraform_*
+  - rm -f terraform.zip
   - terraform -v
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
   - chef gem install bundler
   - chef gem install kitchen-terraform
-  # - chef bundle install
+  - ~/.chefdk/gem/ruby/2.4.0/bin/bundle install
 
 script:
   - echo 'script'
@@ -51,7 +51,6 @@ script:
   - terraform validate
   - cd -
   - terraform -v
-  - chef gem list
   - kitchen test --destroy always
 
 # after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,27 +36,15 @@ before_script:
 
 script:
   - echo 'script'
-  # no terraform through docker until kitchen-terraform supports it
-  # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light init
-  # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light fmt -check=true
-  # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light validate
   - terraform init
   - terraform fmt -check=true
   - terraform validate -var "region=${AWS_REGION}" -var "certificate_arn=arn:aws:iam::123456789012:server-certificate/test_cert-123456789012" -var "health_check_path=/" -var "subnets=[]" -var "vpc_id=vpc-abcde012" -var "alb_name=my-alb" -var "alb_security_groups=[]"
   - docker run --rm -v $(pwd):/app/ --workdir=/app/ -t wata727/tflint --error-with-issues
   - cd examples/test_fixtures
-  # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light init
-  # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light fmt -check=true
-  # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light validate
   - terraform init
   - terraform fmt -check=true
   - terraform validate
-  # FIXME: tflint is unhappy with sourcing a module from a relative dir here.
-  # - docker run --rm -v $(pwd):/data --workdir=/data -t wata727/tflint --error-with-issues
-  - mv main.tf.bak main.tf
   - cd -
-  - pwd
-  - ls -lah
   - terraform -v
   - kitchen test --destroy always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
-
-sudo: true
-
+sudo: false
 dist: trusty
-
 rvm:
   - 2.4.2
 
@@ -22,24 +19,13 @@ before_script:
   - echo 'before_script'
   # Get a random region from the awscli and use it through the remainder of the test cycle.
   - export AWS_REGION=$(docker run --env AWS_DEFAULT_REGION=us-east-2 --env AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --env AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} garland/aws-cli-docker aws ec2 describe-regions --query 'Regions[].{Name:RegionName}' --output text | shuf | head -n1)
-  - echo "using AWS_REGION=${AWS_REGION}"
   - export TF_VAR_region=${AWS_REGION}
-  - curl --output terraform.zip https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_linux_amd64.zip
+  - echo "using AWS_REGION=${AWS_REGION}"
+  - curl --silent --output terraform.zip https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_linux_amd64.zip
   - sha256sum terraform.zip  | grep "402b4333792967986383670134bb52a8948115f83ab6bda35f57fa2c3c9e9279" -q
-  - unzip terraform.zip
-  - chmod +x terraform
-  - mkdir -p ${HOME}/bin
-  - export PATH=${PATH}:${HOME}/bin
-  - mv terraform ${HOME}/bin/
-  - rm -f terraform.zip
+  - unzip terraform.zip ; rm -f terraform.zip; chmod +x terraform
+  - mkdir -p ${HOME}/bin ; export PATH=${PATH}:${HOME}/bin; mv terraform ${HOME}/bin/
   - terraform -v
-  # - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
-  # - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
-  # - chef gem install bundler
-  # - chef gem install kitchen-terraform
-  # seems fragile. How to call? 
-  # - ~/.chefdk/gem/ruby/2.4.0/bin/bundle install
-  # - chef gem list
 
 script:
   - echo 'script'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ before_script:
   - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
   - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
   - chef gem install bundler
-  - chef bundle install
+  - chef gem install kitchen-terraform
+  # - chef bundle install
 
 script:
   - echo 'script'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ before_script:
   - mv terraform ${HOME}/bin/
   - rm -f terraform.zip
   - terraform -v
+  - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
+  - dpkg -i chefdk_2.4.15-1_amd64.deb
+  - chef gem install kitchen-terraform
 
 script:
   - echo 'script'

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - terraform -v
   - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
   - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
-  - chef install bundler
+  - chef gem install bundler
   - chef bundle install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
-sudo: false
+sudo: true
 
 dist: trusty
 
@@ -34,7 +34,7 @@ before_script:
   - rm -f terraform.zip
   - terraform -v
   - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
-  - dpkg -i chefdk_2.4.15-1_amd64.deb
+  - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
   - chef gem install kitchen-terraform
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - terraform validate
   - cd -
   - terraform -v
-  - kitchen test --destroy always
+  - bundle exec kitchen test --destroy always
 
 # after_success:
 #   - echo 'after_success'

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ before_script:
   - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
   - chef gem install bundler
   - chef gem install kitchen-terraform
+  # seems fragile. How to call 
   - ~/.chefdk/gem/ruby/2.4.0/bin/bundle install
+  - chef gem list
 
 script:
   - echo 'script'

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ before_script:
   - terraform -v
   - wget https://packages.chef.io/files/current/chefdk/2.4.15/ubuntu/16.04/chefdk_2.4.15-1_amd64.deb
   - sudo dpkg -i chefdk_2.4.15-1_amd64.deb
-  - chef gem install kitchen-terraform
+  - chef install bundler
+  - chef bundle install
 
 script:
   - echo 'script'
@@ -74,3 +75,10 @@ deploy:
 
 # after_script:
 #   - echo 'after_script'
+
+notifications:
+  email:
+    recipients:
+      - brandon@atscale.run
+    on_success: change # default: change
+    on_failure: change # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ before_script:
   - export AWS_REGION=$(docker run --env AWS_DEFAULT_REGION=us-east-2 --env AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --env AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} garland/aws-cli-docker aws ec2 describe-regions --query 'Regions[].{Name:RegionName}' --output text | shuf | head -n1)
   - echo "using AWS_REGION=${AWS_REGION}"
   - export TF_VAR_region=${AWS_REGION}
-  - wget https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_linux_amd64.zip
-  - unzip terraform_0.10.7_linux_amd64
+  - curl --output terraform.zip https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_linux_amd64.zip
+  - "sha256sum terraform.zip | grep \"402b4333792967986383670134bb52a8948115f83ab6bda35f57fa2c3c9e9279\""
+  - unzip terraform.zip -d terraform
   - chmod +x terraform
   - mkdir -p ${HOME}/bin
   - export PATH=${PATH}:${HOME}/bin
@@ -44,8 +45,6 @@ script:
   - terraform validate -var "region=${AWS_REGION}" -var "certificate_arn=arn:aws:iam::123456789012:server-certificate/test_cert-123456789012" -var "health_check_path=/" -var "subnets=[]" -var "vpc_id=vpc-abcde012" -var "alb_name=my-alb" -var "alb_security_groups=[]"
   - docker run --rm -v $(pwd):/app/ --workdir=/app/ -t wata727/tflint --error-with-issues
   - cd examples/test_fixtures
-  # this line is to change the source of the root module to 2 dirs back which works when validating in CI but when running through test kitchen, we need to source from 3 dirs up, oddly
-  - sed -i.bak 's/\.\.\/\.\.\/\.\./\.\.\/\.\./g' main.tf
   # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light init
   # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light fmt -check=true
   # - docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,61 +1,101 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
+project adheres to [Semantic Versioning](http://semver.org/).
+
+## [2.1.1] - 2017-11-27
+
+#### Added
+
+* variable `health_check_matcher` determines a set or range of successful HTTP
+  status codes for target group health checks (🧀 @mbolek).
+* adapted test kitchen configuration to KT 3.0.x.
 
 ## [2.1.0] - 2017-11-16
+
 #### Added
-* outputs added for listeners - these can be useful for ECR integration (🍰 @mbolek).
-* Moved default `alb_protocols` to HTTP to lower barier of entry in getting started.
+
+* outputs added for listeners - these can be useful for ECR integration (🍰
+  @mbolek).
+* Moved default `alb_protocols` to HTTP to lower barier of entry in getting
+  started.
 
 ## [2.0.0] - 2017-11-06
+
 #### Added
-* added `create_log_bucket` and `enable_logging` to help control logging more granularly.
+
+* added `create_log_bucket` and `enable_logging` to help control logging more
+  granularly.
 
 #### Changed
-* existing log-related variables made more descriptive (this is the breaking change)
+
+* existing log-related variables made more descriptive (this is the breaking
+  change)
 * S3 policy related test made more explicit (⭐ @antonbabenko)
 
 ## [1.0.3] - 2017-10-19
+
 #### Added
+
 * TravisCI configuration added and now passing.
 * badge added to docs.
 * permissions section now in the example readme.
-* placeholder shell script added for CI deployment. Eventually this should conditionally release to the registry when those APIs become available.
+* placeholder shell script added for CI deployment. Eventually this should
+  conditionally release to the registry when those APIs become available.
 
 #### Changed
+
 * altered tf variable `aws_region` to `region`.
-* replaced hardcoding the region to instead use a random region as retrieved by an awscli docker container within CI.
-* example cert is now a regionally-specific resource enabling tests to run in various regions at once and not collide.
+* replaced hardcoding the region to instead use a random region as retrieved by
+  an awscli docker container within CI.
+* example cert is now a regionally-specific resource enabling tests to run in
+  various regions at once and not collide.
 * ruby version bump means `Rhcl` becomes `rhcl`.
 
 ## [1.0.2] - 2017-10-12
+
 #### Added
+
 * moved data sources to dedicated `data.tf` file.
-* `aws_caller_identity` now used to gather account_id rather than using a variable.
+* `aws_caller_identity` now used to gather account_id rather than using a
+  variable.
 * tests added for `target_group` and expanded for `alb`.
-* input variables added for health checks, bucket policy, force_destroy_log_bucket - increasing flexibility.
+* input variables added for health checks, bucket policy,
+  force_destroy_log_bucket - increasing flexibility.
 
 #### Changed
-* altered structure of module to conform to the new [Terraform registry standards](https://www.terraform.io/docs/registry/modules/publish.html#requirements)
-* `principle_account_id` (sp) moved to a data source rather than variable map. Spelling corrected.
-* removed redundant `/test/alb` directory which had module contents copied. Test kitchen now uses the module itself.
+
+* altered structure of module to conform to the new
+  [Terraform registry standards](https://www.terraform.io/docs/registry/modules/publish.html#requirements)
+* `principle_account_id` (sp) moved to a data source rather than variable map.
+  Spelling corrected.
+* removed redundant `/test/alb` directory which had module contents copied. Test
+  kitchen now uses the module itself.
 * pinned examples to provider and terraform versions to harden versioning.
-* self signed cert added to the test fixtures, eliminating the need for manual upload and terraform.tfvars configuration.
-* modules referenced in the test fixture are now sourced from the terraform registry.
-* removed bucket_policy.json in favor of creating the policy via the `aws_iam_policy_document` resource or optionally a variable.
+* self signed cert added to the test fixtures, eliminating the need for manual
+  upload and terraform.tfvars configuration.
+* modules referenced in the test fixture are now sourced from the terraform
+  registry.
+* removed bucket_policy.json in favor of creating the policy via the
+  `aws_iam_policy_document` resource or optionally a variable.
 * stringed list variables moved to native lists
 
 ## [1.0.1] - 2017-09-14
+
 #### Added
+
 * tag maps can now be provided (thanks @kwach)
 
 #### Changed
+
 * optional S3 logging (thanks @marocchino)
 
 ## [1.0.0] - 2017-03-16
+
 #### Added
+
 * Tests and fixtures for ALB components using awspec and test kitchen
 * S3 log bucket and policy rendering for logging now in place
 * root_principle_id added and referenced through a map for s3 bucket policy
@@ -63,10 +103,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * default region removed
 
 #### Changed
-* Restructured project templates to alb dir to add testing. This is a breaking change so upping major version.
+
+* Restructured project templates to alb dir to add testing. This is a breaking
+  change so upping major version.
 * Redundant examples dir removed
 * Updated documentation
 
 ## [0.1.0] - 2017-03-09
+
 #### Added
+
 * Initial release.

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '2.4.2'
 source 'https://rubygems.org/' do
   gem 'kitchen-verifier-awspec'
   gem 'rhcl'
+  gem 'awspec'
 end
 
 gem(

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@ ruby '2.4.2'
 
 source 'https://rubygems.org/' do
   gem 'kitchen-verifier-awspec'
-  gem 'awspec'
   gem 'rhcl'
-  gem(
-    "kitchen-terraform",
-    git: "https://github.com/newcontext-oss/kitchen-terraform",
-    branch: "ncs-alane-3.0.0"
-  )
 end
+
+gem(
+  "kitchen-terraform",
+  git: "https://github.com/newcontext-oss/kitchen-terraform",
+  branch: "ncs-alane-3.0.0"
+)

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,12 @@
 ruby '2.4.2'
 
 source 'https://rubygems.org/' do
-  gem 'kitchen-terraform', '~> 2.0'
   gem 'kitchen-verifier-awspec'
   gem 'awspec'
   gem 'rhcl'
+  gem(
+    "kitchen-terraform",
+    git: "https://github.com/newcontext-oss/kitchen-terraform",
+    branch: "ncs-alane-3.0.0"
+  )
 end

--- a/examples/test_fixtures/main.tf
+++ b/examples/test_fixtures/main.tf
@@ -1,20 +1,18 @@
 terraform {
-  required_version = "~> 0.10.6"
+  required_version = ">= 0.10.0"
 }
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.0.0"
+  version = ">= 1.0.0"
 }
 
-provider "template" {
-  version = "~> 1.0.0"
-}
+provider "template" {}
 
 resource "aws_iam_server_certificate" "fixture_cert" {
   name             = "test_cert-${data.aws_caller_identity.fixtures.account_id}-${var.region}"
-  certificate_body = "${file("${path.module}/../../../examples/test_fixtures/certs/example.crt.pem")}"
-  private_key      = "${file("${path.module}/../../../examples/test_fixtures/certs/example.key.pem")}"
+  certificate_body = "${file("${path.module}/../../examples/test_fixtures/certs/example.crt.pem")}"
+  private_key      = "${file("${path.module}/../../examples/test_fixtures/certs/example.key.pem")}"
 
   lifecycle {
     create_before_destroy = true
@@ -40,7 +38,7 @@ module "security-group" {
 }
 
 module "alb" {
-  source                   = "../../.."
+  source                   = "../.."
   alb_name                 = "my-alb"
   alb_security_groups      = ["${module.security-group.this_security_group_id}"]
   region                   = "${var.region}"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.0.0"
+  version = ">= 1.0.0"
 }
 
 resource "aws_alb" "main" {
@@ -60,7 +60,7 @@ resource "aws_alb_target_group" "target_group" {
     unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
     timeout             = "${var.health_check_timeout}"
     protocol            = "${var.backend_protocol}"
-    matcher             = "${var.health_check_code}"
+    matcher             = "${var.health_check_matcher}"
   }
 
   stickiness {

--- a/test/integration/default/local_alb.rb
+++ b/test/integration/default/local_alb.rb
@@ -4,7 +4,7 @@ require 'rhcl'
 module_vars = Rhcl.parse(File.open('examples/test_fixtures/variables.tf'))
 log_location_prefix = module_vars['variable']['log_location_prefix']['default']
 
-tf_state = JSON.parse(File.open('.kitchen/kitchen-terraform/default-aws/terraform.tfstate').read)
+tf_state = JSON.parse(File.open('terraform.tfstate.d/kitchen-terraform-default-aws/terraform.tfstate').read)
 principal_account_id = tf_state['modules'][0]['outputs']['principal_account_id']['value']
 account_id = tf_state['modules'][0]['outputs']['account_id']['value']
 vpc_id = tf_state['modules'][0]['outputs']['vpc_id']['value']
@@ -14,7 +14,6 @@ region = tf_state['modules'][0]['outputs']['region']['value']
 ENV['AWS_REGION'] = region
 # this must match the format in examples/test_fixtures/locals.tf
 log_bucket_name = 'logs-' + region + '-' + account_id
-# subnet_ids = tf_state['modules'][0]['outputs']['subnet_ids']['value']
 
 describe alb('my-alb') do
   it { should exist }
@@ -25,7 +24,6 @@ describe alb('my-alb') do
   its (:scheme) {should eq 'internet-facing'}
   its (:ip_address_type) {should eq 'ipv4'}
   it { should have_security_group(security_group_id) }
-#   it { should have_subnet(subnet_id) }
 end
 
 describe alb_target_group('my-alb-tg') do
@@ -33,7 +31,6 @@ describe alb_target_group('my-alb-tg') do
     its(:health_check_path) { should eq '/' }
     its(:health_check_port) { should eq 'traffic-port' }
     its(:health_check_protocol) { should eq 'HTTP' }
-    its(:health_check_code) { should eq '200-299' }
     it { should belong_to_alb('my-alb') }
     it { should belong_to_vpc('my-vpc') }
  end

--- a/variables.tf
+++ b/variables.tf
@@ -80,8 +80,8 @@ variable "health_check_unhealthy_threshold" {
   default     = 3
 }
 
-variable "health_check_code" {
-  description = "The HTTP codes that are a success when checking TG health"
+variable "health_check_matcher" {
+  description = "The HTTP codes that are a success when checking TG health."
   default     = "200-299"
 }
 


### PR DESCRIPTION
This change contains:
* much comment clean up
* adapting travis ci code to kitchen terraform 3 (currently pulling from branch)
* renaming the `health_check_code` to `health_check_matcher` (more closely resembles terraform code)