### PR TITLE
Create bucket before provisioning access logs on the ALB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,5 @@ source 'https://rubygems.org/' do
   gem 'kitchen-verifier-awspec'
   gem 'rhcl'
   gem 'awspec'
+  gem 'kitchen-terraform', '>= 3.0.0'
 end
-
-gem(
-  "kitchen-terraform",
-  git: "https://github.com/newcontext-oss/kitchen-terraform",
-  branch: "ncs-alane-3.0.0"
-)

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_alb" "main" {
   tags            = "${merge(var.tags, map("Name", format("%s", var.alb_name)))}"
 
   access_logs {
-    bucket  = "${var.log_bucket_name}"
+    bucket  = "${var.create_log_bucket ? element(concat(aws_s3_bucket.log_bucket.*.id, list("")), 0) : var.log_bucket_name}"
     prefix  = "${var.log_location_prefix}"
     enabled = "${var.enable_logging}"
   }

--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,11 @@ resource "aws_alb" "main" {
   tags            = "${merge(var.tags, map("Name", format("%s", var.alb_name)))}"
 
   access_logs {
-    bucket  = "${var.create_log_bucket ? element(concat(aws_s3_bucket.log_bucket.*.id, list("")), 0) : var.log_bucket_name}"
+    bucket  = "${var.log_bucket_name}"
     prefix  = "${var.log_location_prefix}"
     enabled = "${var.enable_logging}"
   }
+  depends_on = ["aws_s3_bucket.log_bucket"]
 }
 
 data "aws_iam_policy_document" "bucket_policy" {

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "aws_alb" "main" {
     prefix  = "${var.log_location_prefix}"
     enabled = "${var.enable_logging}"
   }
+
   depends_on = ["aws_s3_bucket.log_bucket"]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "enable_logging" {
 }
 
 variable "log_bucket_name" {
-  description = "S3 bucket for storing ALB access logs. Setting this means the module will try to create the bucket."
+  description = "S3 bucket for storing ALB access logs. To create the bucket \"create_log_bucket\" should be set to true."
   default     = ""
 }
 


### PR DESCRIPTION
On three occasions when using this module the S3 bucket was either created after the ALB, or wasn't ready by the time the ALB was trying to set up access logs and I received errors like this:
```
aws_alb.main: Failure configuring ALB attributes: ValidationError: S3Bucket: bucket_name does not exist
	status code: 400, request id: xxxxx-xxxxxx-xxxxxx-xxxxxx-xxxxxx
```

If the option to have the module create the bucket is selected, this ensures the bucket is created before trying to tell the ALB to send logs there.

I tested this with both `create_log_bucket` set to `true` and `false` and it worked both ways. Additionally I ran the `kitchen test` and here is the tail end of the output (it was succesful)
```
       Destroy complete! Resources: 24 destroyed.
$$$$$$ Running command `terraform workspace select default`
       Switched to workspace "default".
$$$$$$ Running command `terraform workspace delete kitchen-terraform-default-aws`
       Deleted workspace "kitchen-terraform-default-aws"!
       Finished destroying <default-aws> (1m8.48s).
       Finished testing <default-aws> (4m10.89s).
-----> Kitchen is finished. (4m11.48s)
```

---

When I was installing the pre-reqs to do the kitchen testing I actually had to change the `kitchen-terraform` gem from branch `ncs-alane-3.0.0` (doesn't exist anymore?) to the SHA of a recent commit in that repo, so that it looked like the following (I did not commit this change):
```diff
diff --git a/Gemfile b/Gemfile
index 19a2c89..5eaf21f 100644
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ end
 gem(
   "kitchen-terraform",
   git: "https://github.com/newcontext-oss/kitchen-terraform",
-  branch: "ncs-alane-3.0.0"
+  branch: "ed1885e77442998781abed5fb26a16dd64310514"
 )```