### PR TITLE
Omitting log_location_prefix creates an invalid bucket policy

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "bucket_policy" {
   statement {
     sid       = "AllowToPutLoadBalancerLogsToS3Bucket"
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${var.log_bucket_name}/${var.log_location_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+    resources = ["arn:aws:s3:::${var.log_bucket_name}/${var.log_location_prefix == "" ? "" : format("%s/", var.log_location_prefix)}AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
When omitting the log_location_prefix, the generated policy is left with an extraneous `/` in the resource.  By default (without a location prefix) the ALB will write to the bucket root, so the created policy will not allow that access.  This adds a slash if a prefix is specified and otherwise omits one.