### PR TITLE
update force_destroy_log_bucket description

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "enable_logging" {
 }
 
 variable "force_destroy_log_bucket" {
-  description = "If set to true and if the log bucket already exists, it will be destroyed and recreated."
+  description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
   default     = false
 }
 


### PR DESCRIPTION
Re: using `force_destroy_log_bucket` - and the `force_destroy` keyword - on `aws_s3_bucket`. This doesn't destroy and recreate the buckets, it just (on destroy) recursively deletes objects in the buckets and cleanly deletes the bucket without error.  The description is misleading, so I've simply put the [upstream resource's description](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html) in here.