### PR TITLE
Enable multiple target groups

### DIFF
--- a/examples/test_fixtures/main.tf
+++ b/examples/test_fixtures/main.tf
@@ -57,4 +57,6 @@ module "alb" {
   subnets                  = "${module.vpc.public_subnets}"
   tags                     = "${local.tags}"
   vpc_id                   = "${module.vpc.vpc_id}"
+  tg_count                 = 2
+  tg_name_suffix           = ["-blu", "-grn"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,7 +48,7 @@ output "principal_account_id" {
   value       = "${data.aws_elb_service_account.main.id}"
 }
 
-output "target_group_arn" {
+output "target_group_arns" {
   description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
-  value       = "${aws_alb_target_group.target_group.arn}"
+  value       = ["${aws_alb_target_group.target_group.*.arn}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,14 @@ variable "target_type" {
   description = "The type of target that you must specify when registering targets with this target group. The possible values are instance (targets are specified by instance ID) or ip (targets are specified by IP address). "
   default     = "instance"
 }
+
+variable "tg_count" {
+  description = "Number of target groups to be created"
+  default = 1
+}
+
+variable "tg_name_suffix" {
+  description = "Suffix to add to the target group name e.g. -blu, -grn"
+  type = "list"
+  default = [""]
+}


### PR DESCRIPTION
Added a count and a name suffix to target group resource. For blue/green deployments it's useful to have target groups so that failover from blue to green is seamless. Using a single tg results in an outage while you're waiting for blue to drain and green in initialize.