### PR TITLE
Add multiple tgs

### DIFF
--- a/examples/test_fixtures/main.tf
+++ b/examples/test_fixtures/main.tf
@@ -57,4 +57,6 @@ module "alb" {
   subnets                  = "${module.vpc.public_subnets}"
   tags                     = "${local.tags}"
   vpc_id                   = "${module.vpc.vpc_id}"
+  tg_count                 = 2
+  tg_name_suffix           = ["-blu", "-grn"]
 }

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_alb_target_group" "target_group" {
 
 resource "aws_alb_listener" "frontend_http" {
   load_balancer_arn = "${aws_alb.main.arn}"
-  port              = "80"
+  port              = "${80+count.index}"
   protocol          = "HTTP"
   count             = "${(contains(var.alb_protocols, "HTTP") ? 1 : 0) == 1 ? var.tg_count : 0}"
 
@@ -70,7 +70,7 @@ resource "aws_alb_listener" "frontend_http" {
 
 resource "aws_alb_listener" "frontend_https" {
   load_balancer_arn = "${aws_alb.main.arn}"
-  port              = "443"
+  port              = "${443+count.index}"
   protocol          = "HTTPS"
   certificate_arn   = "${var.certificate_arn}"
   ssl_policy        = "${var.security_policy}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -52,3 +52,8 @@ output "target_group_arns" {
   description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
   value       = ["${aws_alb_target_group.target_group.*.arn}"]
 }
+
+output "target_group_names" {
+  description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
+  value       = ["${aws_alb_target_group.target_group.*.name}"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,7 +48,7 @@ output "principal_account_id" {
   value       = "${data.aws_elb_service_account.main.id}"
 }
 
-output "target_group_arn" {
+output "target_group_arns" {
   description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
-  value       = "${aws_alb_target_group.target_group.arn}"
+  value       = ["${aws_alb_target_group.target_group.*.arn}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,14 @@ variable "target_type" {
   description = "The type of target that you must specify when registering targets with this target group. The possible values are instance (targets are specified by instance ID) or ip (targets are specified by IP address). "
   default     = "instance"
 }
+
+variable "tg_count" {
+  description = "Number of target groups to be created"
+  default = 1
+}
+
+variable "tg_name_suffix" {
+  description = "Suffix to add to the target group name e.g. -blu, -grn"
+  type = "list"
+  default = [""]
+}


### PR DESCRIPTION
Adds possibility to create multiple target groups with an associated listener. This is useful for blue/green deployments and allows switching between the target groups without downtime. Using a single TG and switching between ASGs causes an outage while waiting for one TG to drain and the other to initialize.