### PR TITLE
Add target_group.name to outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -52,3 +52,8 @@ output "target_group_arn" {
   description = "ARN of the target group. Useful for passing to your Auto Scaling group module."
   value       = "${aws_alb_target_group.target_group.arn}"
 }
+
+output "target_group_name" {
+  description = "Name of the target group. Useful for passing to your CodeDeploy Deployment Group."
+  value       = "${aws_alb_target_group.target_group.name}"
+}


### PR DESCRIPTION
In order to use the target group with a [codedeploy_deployment_group](https://www.terraform.io/docs/providers/aws/r/codedeploy_deployment_group.html) we need to use the name of the target group instead of it's arn.