### PR TITLE
Fix `name_prefix` limiting ALB name descriptiveness to 6 characters

### DIFF
--- a/examples/alb_test_fixture/main.tf
+++ b/examples/alb_test_fixture/main.tf
@@ -7,6 +7,10 @@ provider "aws" {
   region  = "${var.region}"
 }
 
+resource "random_id" "alb_name_suffix" {
+  byte_length = 16
+}
+
 resource "aws_iam_server_certificate" "fixture_cert" {
   name             = "test_cert-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   certificate_body = "${file("${path.module}/../../examples/alb_test_fixture/certs/example.crt.pem")}"
@@ -56,7 +60,7 @@ module "security_group" {
 
 module "alb" {
   source                        = "../.."
-  load_balancer_name            = "test-alb"
+  load_balancer_name            = "test-alb-${random_id.alb_name_suffix.hex}"
   load_balancer_security_groups = ["${module.security_group.this_security_group_id}"]
   log_bucket_name               = "${aws_s3_bucket.log_bucket.id}"
   log_location_prefix           = "${var.log_location_prefix}"

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,6 @@
-locals {
-  prefix_length = "${length(var.load_balancer_name) < 6 ? length(var.load_balancer_name) : 6 }"
-  name_prefix   = "${substr(var.load_balancer_name, 0, local.prefix_length)}"
-}
-
 resource "aws_lb" "application" {
   load_balancer_type         = "application"
-  name_prefix                = "${local.name_prefix}"
+  name                       = "${var.load_balancer_name}"
   internal                   = "${var.load_balancer_is_internal}"
   security_groups            = ["${var.load_balancer_security_groups}"]
   subnets                    = ["${var.subnets}"]


### PR DESCRIPTION
This PR addresses the issue raised in #52.

* Uses `name = ` instead of `name_prefix = ` for the ALB name
* Eliminates forced use of `name_prefix`
* Uses a `random_id` hex value for the test fixture to avoid naming conflict in lieu of `name_prefix` (which appears to have been the motivation behind the change in the first place based on `v3.0.0` CHANGELOG)