### PR TITLE
add target_group_arn_suffixes output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,11 @@ output "target_group_arns" {
   value       = "${slice(concat(aws_lb_target_group.main.*.arn, list("")), 0, var.target_groups_count)}"
 }
 
+output "target_group_arn_suffixes" {
+    description = "ARN suffixes of our target groups - can be used with CloudWatch."
+    value       = "${slice(concat(aws_lb_target_group.main.*.arn_suffix, list("")), 0, var.target_groups_count)}"
+  }
+
 output "target_group_names" {
   description = "Name of the target group. Useful for passing to your CodeDeploy Deployment Group."
   value       = "${slice(concat(aws_lb_target_group.main.*.name, list("")), 0, var.target_groups_count)}"


### PR DESCRIPTION
This is helpful in adding cloud watch monitor(s) for a given number of healthy instances:

From the module invocation, where we specify the list of target groups:
`target_groups = "${list
    (map
      ("name", "${var.app1}", "backend_protocol", "HTTP", "backend_port", "8080"
      ),
    (map
      ("name", "${var.app2}", "backend_protocol", "HTTP", "backend_port", "80"
      )
    )
  )}"`

Cloudwatch usage:
`resource "aws_cloudwatch_metric_alarm" "app1_unhealthy_hosts" {
  alarm_name          = "${var.app1}-unhealthy-host"
  comparison_operator = "LessThanThreshold"
  datapoints_to_alarm = "3"
  evaluation_periods  = "5"
  metric_name         = "HealthyHostCount"
  namespace           = "AWS/ApplicationELB"
  period              = "60"
  statistic           = "Maximum"
  threshold           = "2"

  dimensions {
    TargetGroup   = "${element(module.alb.target_group_arn_suffixes, 0)}"
    LoadBalancer  = "${module.alb.load_balancer_arn_suffix}"
  }

  alarm_description = "${var.environment} ${var.service} ${var.app1} instance(s) failing health checks."

  alarm_actions      = [
    "${module.notify_slack.this_slack_topic_arn}",
    "${aws_sns_topic.pagerduty.arn}"
  ]

  ok_actions      = [
    "${module.notify_slack.this_slack_topic_arn}",
    "${aws_sns_topic.pagerduty.arn}"
  ]
}`