### PR TITLE
Add create_alb variable to support conditional resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ module "alb" {
 Sometimes you need to have a way to create ALB resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_alb`.
 
 ```hcl
-# This VPC will not be created
+# This ALB will not be created
 module "alb" {
   source = "terraform-aws-modules/alb/aws"
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| create_alb | Controls if ALB should be created (it affects almost all resources) | string | `true` | no |
 | enable_deletion_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | string | `false` | no |
 | enable_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | string | `true` | no |
 | extra_ssl_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward). | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ module "alb" {
 }
 ```
 
+## Conditional creation
+
+Sometimes you need to have a way to create ALB resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_alb`.
+
+```hcl
+# This VPC will not be created
+module "alb" {
+  source = "terraform-aws-modules/alb/aws"
+
+  create_alb = false
+  # ... omitted
+}
+```
+
 ## Testing
 
 This module has been packaged with [awspec](https://github.com/k1LoW/awspec) tests through [kitchen](https://kitchen.ci/) and [kitchen-terraform](https://newcontext-oss.github.io/kitchen-terraform/). To run them:

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -16,7 +16,7 @@ resource "aws_lb" "application_no_logs" {
     update = "${var.load_balancer_update_timeout}"
   }
 
-  count = "${var.logging_enabled ? 0 : 1}"
+  count = "${var.logging_enabled && !var.create_alb ? 0 : 1}"
 }
 
 resource "aws_lb_target_group" "main_no_logs" {
@@ -45,7 +45,7 @@ resource "aws_lb_target_group" "main_no_logs" {
   }
 
   tags       = "${merge(var.tags, map("Name", lookup(var.target_groups[count.index], "name")))}"
-  count      = "${var.logging_enabled ? 0 : var.target_groups_count}"
+  count      = "${var.logging_enabled && !var.create_alb ? 0 : var.target_groups_count}"
   depends_on = ["aws_lb.application_no_logs"]
 
   lifecycle {
@@ -57,7 +57,7 @@ resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
   load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled ? 0 : var.http_tcp_listeners_count}"
+  count             = "${var.logging_enabled && !var.create_alb ? 0 : var.http_tcp_listeners_count}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
@@ -71,7 +71,7 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"
   ssl_policy        = "${lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)}"
-  count             = "${var.logging_enabled ? 0 : var.https_listeners_count}"
+  count             = "${var.logging_enabled && !var.create_alb ? 0 : var.https_listeners_count}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
@@ -82,5 +82,5 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
 resource "aws_lb_listener_certificate" "https_listener_no_logs" {
   listener_arn    = "${aws_lb_listener.frontend_https_no_logs.*.arn[lookup(var.extra_ssl_certs[count.index], "https_listener_index")]}"
   certificate_arn = "${lookup(var.extra_ssl_certs[count.index], "certificate_arn")}"
-  count           = "${var.logging_enabled ? 0 : var.extra_ssl_certs_count}"
+  count           = "${var.logging_enabled && !var.create_alb ? 0 : var.extra_ssl_certs_count}"
 }

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -1,3 +1,7 @@
+locals {
+  create_alb_no_logs_enabled = "${var.logging_enabled && !var.create_alb ? 0 : 1}"
+}
+
 resource "aws_lb" "application_no_logs" {
   load_balancer_type         = "application"
   name                       = "${var.load_balancer_name}"
@@ -16,7 +20,7 @@ resource "aws_lb" "application_no_logs" {
     update = "${var.load_balancer_update_timeout}"
   }
 
-  count = "${var.logging_enabled && !var.create_alb ? 0 : 1}"
+  count = "${local.create_alb_no_logs_enabled ? 0 : 1}"
 }
 
 resource "aws_lb_target_group" "main_no_logs" {
@@ -45,7 +49,7 @@ resource "aws_lb_target_group" "main_no_logs" {
   }
 
   tags       = "${merge(var.tags, map("Name", lookup(var.target_groups[count.index], "name")))}"
-  count      = "${var.logging_enabled && !var.create_alb ? 0 : var.target_groups_count}"
+  count      = "${local.create_alb_no_logs_enabled ? 0 : var.target_groups_count}"
   depends_on = ["aws_lb.application_no_logs"]
 
   lifecycle {
@@ -57,7 +61,7 @@ resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
   load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled && !var.create_alb ? 0 : var.http_tcp_listeners_count}"
+  count             = "${local.create_alb_no_logs_enabled ? 0 : var.http_tcp_listeners_count}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
@@ -71,7 +75,7 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"
   ssl_policy        = "${lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)}"
-  count             = "${var.logging_enabled && !var.create_alb ? 0 : var.https_listeners_count}"
+  count             = "${local.create_alb_no_logs_enabled ? 0 : var.https_listeners_count}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
@@ -82,5 +86,5 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
 resource "aws_lb_listener_certificate" "https_listener_no_logs" {
   listener_arn    = "${aws_lb_listener.frontend_https_no_logs.*.arn[lookup(var.extra_ssl_certs[count.index], "https_listener_index")]}"
   certificate_arn = "${lookup(var.extra_ssl_certs[count.index], "certificate_arn")}"
-  count           = "${var.logging_enabled && !var.create_alb ? 0 : var.extra_ssl_certs_count}"
+  count           = "${local.create_alb_no_logs_enabled ? 0 : var.extra_ssl_certs_count}"
 }

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -1,3 +1,7 @@
+locals {
+  create_alb_with_logging_enabled = "${var.logging_enabled && var.create_alb ? 1 : 0}"
+}
+
 resource "aws_lb" "application" {
   load_balancer_type         = "application"
   name                       = "${var.load_balancer_name}"
@@ -22,7 +26,7 @@ resource "aws_lb" "application" {
     update = "${var.load_balancer_update_timeout}"
   }
 
-  count = "${var.logging_enabled && var.create_alb ? 1 : 0}"
+  count = "${local.create_alb_with_logging_enabled ? 1 : 0}"
 }
 
 resource "aws_lb_target_group" "main" {
@@ -51,7 +55,7 @@ resource "aws_lb_target_group" "main" {
   }
 
   tags       = "${merge(var.tags, map("Name", lookup(var.target_groups[count.index], "name")))}"
-  count      = "${var.logging_enabled && var.create_alb ? var.target_groups_count : 0}"
+  count      = "${local.create_alb_with_logging_enabled ? var.target_groups_count : 0}"
   depends_on = ["aws_lb.application"]
 
   lifecycle {
@@ -63,7 +67,7 @@ resource "aws_lb_listener" "frontend_http_tcp" {
   load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled && var.create_alb ? var.http_tcp_listeners_count : 0}"
+  count             = "${local.create_alb_with_logging_enabled ? var.http_tcp_listeners_count : 0}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
@@ -77,7 +81,7 @@ resource "aws_lb_listener" "frontend_https" {
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"
   ssl_policy        = "${lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)}"
-  count             = "${var.logging_enabled && var.create_alb ? var.https_listeners_count : 0}"
+  count             = "${local.create_alb_with_logging_enabled ? var.https_listeners_count : 0}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
@@ -88,5 +92,5 @@ resource "aws_lb_listener" "frontend_https" {
 resource "aws_lb_listener_certificate" "https_listener" {
   listener_arn    = "${aws_lb_listener.frontend_https.*.arn[lookup(var.extra_ssl_certs[count.index], "https_listener_index")]}"
   certificate_arn = "${lookup(var.extra_ssl_certs[count.index], "certificate_arn")}"
-  count           = "${var.logging_enabled && var.create_alb ? var.extra_ssl_certs_count : 0}"
+  count           = "${local.create_alb_with_logging_enabled ? var.extra_ssl_certs_count : 0}"
 }

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -22,7 +22,7 @@ resource "aws_lb" "application" {
     update = "${var.load_balancer_update_timeout}"
   }
 
-  count = "${var.logging_enabled ? 1 : 0}"
+  count = "${var.logging_enabled && var.create_alb ? 1 : 0}"
 }
 
 resource "aws_lb_target_group" "main" {
@@ -51,7 +51,7 @@ resource "aws_lb_target_group" "main" {
   }
 
   tags       = "${merge(var.tags, map("Name", lookup(var.target_groups[count.index], "name")))}"
-  count      = "${var.logging_enabled ? var.target_groups_count : 0}"
+  count      = "${var.logging_enabled && var.create_alb ? var.target_groups_count : 0}"
   depends_on = ["aws_lb.application"]
 
   lifecycle {
@@ -63,7 +63,7 @@ resource "aws_lb_listener" "frontend_http_tcp" {
   load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled ? var.http_tcp_listeners_count : 0}"
+  count             = "${var.logging_enabled && var.create_alb ? var.http_tcp_listeners_count : 0}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
@@ -77,7 +77,7 @@ resource "aws_lb_listener" "frontend_https" {
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"
   ssl_policy        = "${lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)}"
-  count             = "${var.logging_enabled ? var.https_listeners_count : 0}"
+  count             = "${var.logging_enabled && var.create_alb ? var.https_listeners_count : 0}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
@@ -88,5 +88,5 @@ resource "aws_lb_listener" "frontend_https" {
 resource "aws_lb_listener_certificate" "https_listener" {
   listener_arn    = "${aws_lb_listener.frontend_https.*.arn[lookup(var.extra_ssl_certs[count.index], "https_listener_index")]}"
   certificate_arn = "${lookup(var.extra_ssl_certs[count.index], "certificate_arn")}"
-  count           = "${var.logging_enabled ? var.extra_ssl_certs_count : 0}"
+  count           = "${var.logging_enabled && var.create_alb ? var.extra_ssl_certs_count : 0}"
 }

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -1,5 +1,5 @@
 locals {
-  create_alb_with_logging_enabled = "${var.logging_enabled && var.create_alb ? 1 : 0}"
+  create_alb_with_logging_enabled = "${var.logging_enabled == true && var.create_alb == true ? 1 : 0}"
 }
 
 resource "aws_lb" "application" {

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,20 @@ Balancer (ALB) running over HTTP/HTTPS. Available through the [Terraform registr
 * }
 * ```
 
+* ## Conditional creation
+
+* Sometimes you need to have a way to create ALB resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_alb`.
+
+* ```hcl
+* # This ALB will not be created
+* module "alb" {
+*   source = "terraform-aws-modules/alb/aws"
+*
+*   create_alb = false
+*   # ... omitted
+* }
+* ```
+
 * ## Testing
 
 * This module has been packaged with [awspec](https://github.com/k1LoW/awspec) tests through [kitchen](https://kitchen.ci/) and [kitchen-terraform](https://newcontext-oss.github.io/kitchen-terraform/). To run them:

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,54 +1,54 @@
 output "dns_name" {
   description = "The DNS name of the load balancer."
-  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name), 0)}"
+  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name, list("")), 0)}"
 }
 
 output "http_tcp_listener_arns" {
   description = "The ARN of the TCP and HTTP load balancer listeners created."
-  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp.*.arn, aws_lb_listener.frontend_http_tcp_no_logs.*.arn), 0, var.http_tcp_listeners_count)}"
+  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp.*.arn, aws_lb_listener.frontend_http_tcp_no_logs.*.arn, list("")), 0, var.http_tcp_listeners_count)}"
 }
 
 output "http_tcp_listener_ids" {
   description = "The IDs of the TCP and HTTP load balancer listeners created."
-  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp.*.id, aws_lb_listener.frontend_http_tcp_no_logs.*.id), 0, var.http_tcp_listeners_count)}"
+  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp.*.id, aws_lb_listener.frontend_http_tcp_no_logs.*.id, list("")), 0, var.http_tcp_listeners_count)}"
 }
 
 output "https_listener_arns" {
   description = "The ARNs of the HTTPS load balancer listeners created."
-  value       = "${slice(concat(aws_lb_listener.frontend_https.*.arn, aws_lb_listener.frontend_https_no_logs.*.arn), 0, var.https_listeners_count)}"
+  value       = "${slice(concat(aws_lb_listener.frontend_https.*.arn, aws_lb_listener.frontend_https_no_logs.*.arn, list("")), 0, var.https_listeners_count)}"
 }
 
 output "https_listener_ids" {
   description = "The IDs of the load balancer listeners created."
-  value       = "${slice(concat(aws_lb_listener.frontend_https.*.id, aws_lb_listener.frontend_https_no_logs.*.id), 0, var.https_listeners_count)}"
+  value       = "${slice(concat(aws_lb_listener.frontend_https.*.id, aws_lb_listener.frontend_https_no_logs.*.id, list("")), 0, var.https_listeners_count)}"
 }
 
 output "load_balancer_arn_suffix" {
   description = "ARN suffix of our load balancer - can be used with CloudWatch."
-  value       = "${element(concat(aws_lb.application.*.arn_suffix, aws_lb.application_no_logs.*.arn_suffix), 0)}"
+  value       = "${element(concat(aws_lb.application.*.arn_suffix, aws_lb.application_no_logs.*.arn_suffix, list("")), 0)}"
 }
 
 output "load_balancer_id" {
   description = "The ID and ARN of the load balancer we created."
-  value       = "${element(concat(aws_lb.application.*.id, aws_lb.application_no_logs.*.id), 0)}"
+  value       = "${element(concat(aws_lb.application.*.id, aws_lb.application_no_logs.*.id, list("")), 0)}"
 }
 
 output "load_balancer_zone_id" {
   description = "The zone_id of the load balancer to assist with creating DNS records."
-  value       = "${element(concat(aws_lb.application.*.zone_id, aws_lb.application_no_logs.*.zone_id), 0)}"
+  value       = "${element(concat(aws_lb.application.*.zone_id, aws_lb.application_no_logs.*.zone_id, list("")), 0)}"
 }
 
 output "target_group_arns" {
   description = "ARNs of the target groups. Useful for passing to your Auto Scaling group."
-  value       = "${slice(concat(aws_lb_target_group.main.*.arn, aws_lb_target_group.main_no_logs.*.arn), 0, var.target_groups_count)}"
+  value       = "${slice(concat(aws_lb_target_group.main.*.arn, aws_lb_target_group.main_no_logs.*.arn, list("")), 0, var.target_groups_count)}"
 }
 
 output "target_group_arn_suffixes" {
   description = "ARN suffixes of our target groups - can be used with CloudWatch."
-  value       = "${slice(concat(aws_lb_target_group.main.*.arn_suffix, aws_lb_target_group.main_no_logs.*.arn_suffix), 0, var.target_groups_count)}"
+  value       = "${slice(concat(aws_lb_target_group.main.*.arn_suffix, aws_lb_target_group.main_no_logs.*.arn_suffix, list("")), 0, var.target_groups_count)}"
 }
 
 output "target_group_names" {
   description = "Name of the target group. Useful for passing to your CodeDeploy Deployment Group."
-  value       = "${slice(concat(aws_lb_target_group.main.*.name, aws_lb_target_group.main_no_logs.*.name), 0, var.target_groups_count)}"
+  value       = "${slice(concat(aws_lb_target_group.main.*.name, aws_lb_target_group.main_no_logs.*.name, list("")), 0, var.target_groups_count)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "create_alb" {
+  description = "Controls if ALB should be created (it affects almost all resources)"
+  default     = true
+}
+
 variable "enable_deletion_protection" {
   description = "If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false."
   default     = false


### PR DESCRIPTION
# PR o'clock

## Description

A little pull request because sometimes you need to have a way to create ALB resources conditionally but Terraform does not allow to use count inside module block, so the solution is to specify argument create_alb.

I added local variables and updated ReadMe as you asked.
