### PR TITLE
Add variable to support setting cross-zone-load-balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| enable_cross_zone_load_balancing | Indicates whether cross zone load balancing should be enabled in application load balancers. | string | `false` | no |
 | enable_deletion_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | string | `false` | no |
 | enable_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | string | `true` | no |
 | extra_ssl_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward). | list | `<list>` | no |

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -1,14 +1,15 @@
 resource "aws_lb" "application_no_logs" {
-  load_balancer_type         = "application"
-  name                       = "${var.load_balancer_name}"
-  internal                   = "${var.load_balancer_is_internal}"
-  security_groups            = ["${var.security_groups}"]
-  subnets                    = ["${var.subnets}"]
-  idle_timeout               = "${var.idle_timeout}"
-  enable_deletion_protection = "${var.enable_deletion_protection}"
-  enable_http2               = "${var.enable_http2}"
-  ip_address_type            = "${var.ip_address_type}"
-  tags                       = "${merge(var.tags, map("Name", var.load_balancer_name))}"
+  load_balancer_type               = "application"
+  name                             = "${var.load_balancer_name}"
+  internal                         = "${var.load_balancer_is_internal}"
+  security_groups                  = ["${var.security_groups}"]
+  subnets                          = ["${var.subnets}"]
+  idle_timeout                     = "${var.idle_timeout}"
+  enable_cross_zone_load_balancing = "${var.enable_cross_zone_load_balancing}"
+  enable_deletion_protection       = "${var.enable_deletion_protection}"
+  enable_http2                     = "${var.enable_http2}"
+  ip_address_type                  = "${var.ip_address_type}"
+  tags                             = "${merge(var.tags, map("Name", var.load_balancer_name))}"
 
   timeouts {
     create = "${var.load_balancer_create_timeout}"

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -1,14 +1,15 @@
 resource "aws_lb" "application" {
-  load_balancer_type         = "application"
-  name                       = "${var.load_balancer_name}"
-  internal                   = "${var.load_balancer_is_internal}"
-  security_groups            = ["${var.security_groups}"]
-  subnets                    = ["${var.subnets}"]
-  idle_timeout               = "${var.idle_timeout}"
-  enable_deletion_protection = "${var.enable_deletion_protection}"
-  enable_http2               = "${var.enable_http2}"
-  ip_address_type            = "${var.ip_address_type}"
-  tags                       = "${merge(var.tags, map("Name", var.load_balancer_name))}"
+  load_balancer_type               = "application"
+  name                             = "${var.load_balancer_name}"
+  internal                         = "${var.load_balancer_is_internal}"
+  security_groups                  = ["${var.security_groups}"]
+  subnets                          = ["${var.subnets}"]
+  idle_timeout                     = "${var.idle_timeout}"
+  enable_cross_zone_load_balancing = "${var.enable_cross_zone_load_balancing}"
+  enable_deletion_protection       = "${var.enable_deletion_protection}"
+  enable_http2                     = "${var.enable_http2}"
+  ip_address_type                  = "${var.ip_address_type}"
+  tags                             = "${merge(var.tags, map("Name", var.load_balancer_name))}"
 
   access_logs {
     enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "enable_http2" {
   default     = true
 }
 
+variable "enable_cross_zone_load_balancing" {
+  description = "Indicates whether cross zone load balancing should be enabled in application load balancers."
+  default     = false
+}
+
 variable "extra_ssl_certs" {
   description = "A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward)."
   type        = "list"


### PR DESCRIPTION
# Support Enabling cross zone load balancing

## Description

I added a new variable to support enabling cross zone load balancing.

The [argument of `aws_lb` resource](https://www.terraform.io/docs/providers/aws/r/lb.html#enable_cross_zone_load_balancing) is called `enable_cross_zone_load_balancing` and is `false` by default so I do the same thing in the module.

## Note on testing

I tested this within our own running AWS environment and it seems to work properly.

The test set that was documented (ie. `bundle exec kitchen test`) somehow didn't work for me.

I ran the test using a docker container with ruby as follow:

```bash
docker run -it --rm -v $PWD:/source -w /source --env-file=$HOME/.aws/tf_test_env -v $HOME/Downloads/linux-terraform:/bin/terraform --entrypoint bash ruby:2.4.2
root@327539cefb64:/source# gem install bundler && bundle install
Fetching: bundler-1.16.2.gem (100%)
....
REDACTED
....
Post-install message from kitchen-terraform:
DEPRECATING: the current version of Ruby is 2.2.7; this version will not be supported in an upcoming major release of Kitchen-Terraform
root@327539cefb64:/source# bundle exec kitchen test
-----> Starting Kitchen (v1.21.2)
$$$$$$ Running command `terraform version`
       Terraform v0.11.7

$$$$$$ Terraform v0.11.7 is supported
....
REDACTED
....
       Error: Error applying plan:

       5 error(s) occurred:

       * module.alb.output.target_group_arns: slice: to index must be <= length of the input list in:

       ${slice(concat(aws_lb_target_group.main.*.arn, aws_lb_target_group.main_no_logs.*.arn), 0, var.target_groups_count)}
       * module.alb.output.https_listener_arns: slice: to index must be <= length of the input list in:

       ${slice(concat(aws_lb_listener.frontend_https.*.arn, aws_lb_listener.frontend_https_no_logs.*.arn), 0, var.https_listeners_count)}
       * module.vpc.output.vpc_id: variable "this" is nil, but no error was reported
       * module.alb.output.http_tcp_listener_arns: slice: to index must be <= length of the input list in:

       ${slice(concat(aws_lb_listener.frontend_http_tcp.*.arn, aws_lb_listener.frontend_http_tcp_no_logs.*.arn), 0, var.http_tcp_listeners_count)}
       * module.alb.output.load_balancer_id: element: element() may not be used with an empty list in:

       ${element(concat(aws_lb.application.*.id, aws_lb.application_no_logs.*.id), 0)}

       Terraform does not automatically rollback in the face of errors.
       Instead, your Terraform state file has been partially updated with
       any resources that successfully completed. Please address the error
       above and apply again to incrementally change your infrastructure.


>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Destroy failed on instance <default-aws>.  Please see .kitchen/logs/default-aws.log for more details
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

The file `~/.aws/tf_test_env` contains the environment variables that is necessary to access my AWS account along with `TF_VAR_region`
```
AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXXXX
AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
AWS_DEFAULT_REGION=us-west-2
TF_VAR_region=us-west-2
```

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [x] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [x] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the description above
