### PR TITLE
Feature http_tcp_listeners - Add redirect default action type

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | extra_ssl_certs_count | A manually provided count/length of the extra_ssl_certs list of maps since the list cannot be computed. | string | `0` | no |
 | http_tcp_listeners_forward | A list of maps describing the HTTP listeners with forward default action type for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list | `<list>` | no |
 | http_tcp_listeners_forward_count | A manually provided count/length of the http_tcp_listeners_forward list of maps since the list cannot be computed. | string | `0` | no |
-| http_tcp_listeners_redirect | A list of maps describing the HTTP listeners with forward default redirect for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list | `<list>` | no |
+| http_tcp_listeners_redirect | A list of maps describing the HTTP listeners with redirect default action type for this ALB. Optional key/values are in the default_action_redirect_defaults variable. | list | `<list>` | no |
 | http_tcp_listeners_redirect_count | A manually provided count/length of the http_tcp_listeners_redirect list of maps since the list cannot be computed. | string | `0` | no |
 | https_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, certificate_arn. Optional key/values: ssl_policy (defaults to ELBSecurityPolicy-2016-08), target_group_index (defaults to 0) | list | `<list>` | no |
 | https_listeners_count | A manually provided count/length of the https_listeners list of maps since the list cannot be computed. | string | `0` | no |

--- a/README.md
+++ b/README.md
@@ -43,20 +43,20 @@ A full example leveraging other community modules is contained in the [examples/
 
 ```hcl
 module "alb" {
-  source                        = "terraform-aws-modules/alb/aws"
-  load_balancer_name            = "my-alb"
-  security_groups               = ["sg-edcd9784", "sg-edcd9785"]
-  log_bucket_name               = "logs-us-east-2-123456789012"
-  log_location_prefix           = "my-alb-logs"
-  subnets                       = ["subnet-abcde012", "subnet-bcde012a"]
-  tags                          = "${map("Environment", "test")}"
-  vpc_id                        = "vpc-abcde012"
-  https_listeners               = "${list(map("certificate_arn", "arn:aws:iam::123456789012:server-certificate/test_cert-123456789012", "port", 443))}"
-  https_listeners_count         = "1"
-  http_tcp_listeners            = "${list(map("port", "80", "protocol", "HTTP"))}"
-  http_tcp_listeners_count      = "1"
-  target_groups                 = "${list(map("name", "foo", "backend_protocol", "HTTP", "backend_port", "80"))}"
-  target_groups_count           = "1"
+  source                           = "terraform-aws-modules/alb/aws"
+  load_balancer_name               = "my-alb"
+  security_groups                  = ["sg-edcd9784", "sg-edcd9785"]
+  log_bucket_name                  = "logs-us-east-2-123456789012"
+  log_location_prefix              = "my-alb-logs"
+  subnets                          = ["subnet-abcde012", "subnet-bcde012a"]
+  tags                             = "${map("Environment", "test")}"
+  vpc_id                           = "vpc-abcde012"
+  https_listeners                  = "${list(map("certificate_arn", "arn:aws:iam::123456789012:server-certificate/test_cert-123456789012", "port", 443))}"
+  https_listeners_count            = "1"
+  http_tcp_listeners_forward       = "${list(map("port", "80", "protocol", "HTTP"))}"
+  http_tcp_listeners_forward_count = "1"
+  target_groups                    = "${list(map("name", "foo", "backend_protocol", "HTTP", "backend_port", "80"))}"
+  target_groups_count              = "1"
 }
 ```
 
@@ -116,8 +116,10 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | enable_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | string | `true` | no |
 | extra_ssl_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward). | list | `<list>` | no |
 | extra_ssl_certs_count | A manually provided count/length of the extra_ssl_certs list of maps since the list cannot be computed. | string | `0` | no |
-| http_tcp_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list | `<list>` | no |
-| http_tcp_listeners_count | A manually provided count/length of the http_tcp_listeners list of maps since the list cannot be computed. | string | `0` | no |
+| http_tcp_listeners_forward | A list of maps describing the HTTP listeners with forward default action type for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list | `<list>` | no |
+| http_tcp_listeners_forward_count | A manually provided count/length of the http_tcp_listeners_forward list of maps since the list cannot be computed. | string | `0` | no |
+| http_tcp_listeners_redirect | A list of maps describing the HTTP listeners with forward default redirect for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list | `<list>` | no |
+| http_tcp_listeners_redirect_count | A manually provided count/length of the http_tcp_listeners_redirect list of maps since the list cannot be computed. | string | `0` | no |
 | https_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, certificate_arn. Optional key/values: ssl_policy (defaults to ELBSecurityPolicy-2016-08), target_group_index (defaults to 0) | list | `<list>` | no |
 | https_listeners_count | A manually provided count/length of the https_listeners list of maps since the list cannot be computed. | string | `0` | no |
 | idle_timeout | The time in seconds that the connection is allowed to be idle. | string | `60` | no |
@@ -144,8 +146,10 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | Name | Description |
 |------|-------------|
 | dns_name | The DNS name of the load balancer. |
-| http_tcp_listener_arns | The ARN of the TCP and HTTP load balancer listeners created. |
-| http_tcp_listener_ids | The IDs of the TCP and HTTP load balancer listeners created. |
+| http_tcp_listener_forward_arns | The ARN of the TCP and HTTP load balancer listeners created. |
+| http_tcp_listener_forward_ids | The IDs of the TCP and HTTP load balancer listeners created. |
+| http_tcp_listener_redirect_arns | The ARN of the TCP and HTTP load balancer listeners created. |
+| http_tcp_listener_redirect_ids | The IDs of the TCP and HTTP load balancer listeners created. |
 | https_listener_arns | The ARNs of the HTTPS load balancer listeners created. |
 | https_listener_ids | The IDs of the load balancer listeners created. |
 | load_balancer_arn_suffix | ARN suffix of our load balancer - can be used with CloudWatch. |

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -66,24 +66,35 @@ resource "aws_lb_target_group" "main_no_logs" {
 #   }
 # }
 
-resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
+resource "aws_lb_listener" "frontend_http_tcp_forward_no_logs" {
   load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
-  port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
-  protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled && var.enable_http_tcp_listener_redirect ? 0 : var.http_tcp_listeners_count}"
+  port              = "${lookup(var.http_tcp_listeners_forward[count.index], "port")}"
+  protocol          = "${lookup(var.http_tcp_listeners_forward[count.index], "protocol")}"
+  count             = "${var.logging_enabled ? 0 : var.http_tcp_listeners_forward_count}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
-    type             = "${lookup(var.http_tcp_listeners[count.index], "default_action_type", "forward")}"
+    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners_forward[count.index], "target_group_index", 0)]}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "frontend_http_tcp_redirect_no_logs" {
+  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
+  port              = "${lookup(var.http_tcp_listeners_redirect[count.index], "port")}"
+  protocol          = "${lookup(var.http_tcp_listeners_redirect[count.index], "protocol")}"
+  count             = "${var.logging_enabled ? 0 : var.http_tcp_listeners_redirect_count}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners_redirect[count.index], "target_group_index", 0)]}"
+    type             = "redirect"
 
     redirect {
-      count       = "${lookup(var.http_tcp_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
-      host        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_host", lookup(var.http_tcp_listeners_redirect_defaults, "host"))})}"
-      path        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_path", lookup(var.http_tcp_listeners_redirect_defaults, "path"))}"
-      port        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_port", lookup(var.http_tcp_listeners_redirect_defaults, "port"))}"
-      protocol    = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_protocol", lookup(var.http_tcp_listeners_redirect_defaults, "protocol"))}"
-      query       = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_query", lookup(var.http_tcp_listeners_redirect_defaults, "query"))}"
-      status_code = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_status_code", lookup(var.http_tcp_listeners_redirect_defaults, "status_code"))}"
+      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))})}"
+      path        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
+      port        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
+      protocol    = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"
+      query       = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_query", lookup(var.default_action_redirect_defaults, "query"))}"
+      status_code = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_status_code", lookup(var.default_action_redirect_defaults, "status_code"))}"
     }
   }
 }
@@ -98,17 +109,7 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
-    type             = "${lookup(var.https_listeners[count.index], "default_action_type", "forward")}"
-
-    redirect {
-      count       = "${lookup(var.https_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
-      host        = "${lookup(var.https_listeners[count.index], "default_action_redirect_host", lookup(var.default_action_redirect_defaults, "host"))}"
-      path        = "${lookup(var.https_listeners[count.index], "default_action_redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
-      port        = "${lookup(var.https_listeners[count.index], "default_action_redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
-      protocol    = "${lookup(var.https_listeners[count.index], "default_action_redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"
-      query       = "${lookup(var.https_listeners[count.index], "default_action_redirect_query", lookup(var.default_action_redirect_defaults, "query"))}"
-      status_code = "${lookup(var.https_listeners[count.index], "default_action_redirect_status_code", lookup(var.default_action_redirect_defaults, "status_code"))}"
-    }
+    type             = "forward"
   }
 }
 

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -55,18 +55,6 @@ resource "aws_lb_target_group" "main_no_logs" {
   }
 }
 
-# resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
-#   load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
-#   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
-#   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-#   count             = "${var.logging_enabled ? 0 : var.http_tcp_listeners_count}"
-
-#   default_action {
-#     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
-#     type             = "forward"
-#   }
-# }
-
 resource "aws_lb_listener" "frontend_http_tcp_forward_no_logs" {
   load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
   port              = "${lookup(var.http_tcp_listeners_forward[count.index], "port")}"
@@ -90,7 +78,7 @@ resource "aws_lb_listener" "frontend_http_tcp_redirect_no_logs" {
     type             = "redirect"
 
     redirect {
-      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))}""
+      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))}"
       path        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
       port        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
       protocol    = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -54,15 +54,37 @@ resource "aws_lb_target_group" "main_no_logs" {
   }
 }
 
+# resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
+#   load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
+#   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
+#   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
+#   count             = "${var.logging_enabled ? 0 : var.http_tcp_listeners_count}"
+
+#   default_action {
+#     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
+#     type             = "forward"
+#   }
+# }
+
 resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
   load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled ? 0 : var.http_tcp_listeners_count}"
+  count             = "${var.logging_enabled && var.enable_http_tcp_listener_redirect ? 0 : var.http_tcp_listeners_count}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
-    type             = "forward"
+    type             = "${lookup(var.http_tcp_listeners[count.index], "default_action_type", "forward")}"
+
+    redirect {
+      count       = "${lookup(var.http_tcp_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
+      host        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_host", lookup(var.http_tcp_listeners_redirect_defaults, "host"))})}"
+      path        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_path", lookup(var.http_tcp_listeners_redirect_defaults, "path"))}"
+      port        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_port", lookup(var.http_tcp_listeners_redirect_defaults, "port"))}"
+      protocol    = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_protocol", lookup(var.http_tcp_listeners_redirect_defaults, "protocol"))}"
+      query       = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_query", lookup(var.http_tcp_listeners_redirect_defaults, "query"))}"
+      status_code = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_status_code", lookup(var.http_tcp_listeners_redirect_defaults, "status_code"))}"
+    }
   }
 }
 
@@ -76,7 +98,17 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
-    type             = "forward"
+    type             = "${lookup(var.https_listeners[count.index], "default_action_type", "forward")}"
+
+    redirect {
+      count       = "${lookup(var.https_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
+      host        = "${lookup(var.https_listeners[count.index], "default_action_redirect_host", lookup(var.default_action_redirect_defaults, "host"))}"
+      path        = "${lookup(var.https_listeners[count.index], "default_action_redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
+      port        = "${lookup(var.https_listeners[count.index], "default_action_redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
+      protocol    = "${lookup(var.https_listeners[count.index], "default_action_redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"
+      query       = "${lookup(var.https_listeners[count.index], "default_action_redirect_query", lookup(var.default_action_redirect_defaults, "query"))}"
+      status_code = "${lookup(var.https_listeners[count.index], "default_action_redirect_status_code", lookup(var.default_action_redirect_defaults, "status_code"))}"
+    }
   }
 }
 

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -90,7 +90,7 @@ resource "aws_lb_listener" "frontend_http_tcp_redirect_no_logs" {
     type             = "redirect"
 
     redirect {
-      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))})}"
+      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))}""
       path        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
       port        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
       protocol    = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -61,18 +61,6 @@ resource "aws_lb_target_group" "main" {
   }
 }
 
-# resource "aws_lb_listener" "frontend_http_tcp" {
-#   load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application.*.arn), 0)}"
-#   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
-#   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-#   count             = "${var.logging_enabled ? var.http_tcp_listeners_count : 0}"
-
-#   default_action {
-#     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
-#     type             = "forward"
-#   }
-# }
-
 resource "aws_lb_listener" "frontend_http_tcp_forward" {
   load_balancer_arn = "${element(concat(aws_lb.application.*.arn, list("")), 0)}"
   port              = "${lookup(var.http_tcp_listeners_forward[count.index], "port")}"

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -60,15 +60,37 @@ resource "aws_lb_target_group" "main" {
   }
 }
 
+# resource "aws_lb_listener" "frontend_http_tcp" {
+#   load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
+#   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
+#   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
+#   count             = "${var.logging_enabled ? var.http_tcp_listeners_count : 0}"
+
+#   default_action {
+#     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
+#     type             = "forward"
+#   }
+# }
+
 resource "aws_lb_listener" "frontend_http_tcp" {
-  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
+  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled ? var.http_tcp_listeners_count : 0}"
+  count             = "${var.logging_enabled && var.enable_http_tcp_listener_redirect ? 0 : var.http_tcp_listeners_count}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
-    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
+    type             = "${lookup(var.http_tcp_listeners[count.index], "default_action_type", "forward")}"
+
+    redirect {
+      count       = "${lookup(var.http_tcp_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
+      host        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_host", lookup(var.http_tcp_listeners_redirect_defaults, "host"))}"
+      path        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_path", lookup(var.http_tcp_listeners_redirect_defaults, "path"))}"
+      port        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_port", lookup(var.http_tcp_listeners_redirect_defaults, "port"))}"
+      protocol    = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_protocol", lookup(var.http_tcp_listeners_redirect_defaults, "protocol"))}"
+      query       = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_query", lookup(var.http_tcp_listeners_redirect_defaults, "query"))}"
+      status_code = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_status_code", lookup(var.http_tcp_listeners_redirect_defaults, "status_code"))}"
+    }
   }
 }
 
@@ -82,7 +104,17 @@ resource "aws_lb_listener" "frontend_https" {
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
-    type             = "forward"
+    type             = "${lookup(var.https_listeners[count.index], "default_action_type", "forward")}"
+
+    redirect {
+      count       = "${lookup(var.https_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
+      host        = "${lookup(var.https_listeners[count.index], "default_action_redirect_host", lookup(var.default_action_redirect_defaults, "host"))}"
+      path        = "${lookup(var.https_listeners[count.index], "default_action_redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
+      port        = "${lookup(var.https_listeners[count.index], "default_action_redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
+      protocol    = "${lookup(var.https_listeners[count.index], "default_action_redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"
+      query       = "${lookup(var.https_listeners[count.index], "default_action_redirect_query", lookup(var.default_action_redirect_defaults, "query"))}"
+      status_code = "${lookup(var.https_listeners[count.index], "default_action_redirect_status_code", lookup(var.default_action_redirect_defaults, "status_code"))}"
+    }
   }
 }
 

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -61,7 +61,7 @@ resource "aws_lb_target_group" "main" {
 }
 
 # resource "aws_lb_listener" "frontend_http_tcp" {
-#   load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
+#   load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application.*.arn), 0)}"
 #   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
 #   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
 #   count             = "${var.logging_enabled ? var.http_tcp_listeners_count : 0}"
@@ -72,30 +72,41 @@ resource "aws_lb_target_group" "main" {
 #   }
 # }
 
-resource "aws_lb_listener" "frontend_http_tcp" {
-  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
-  port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
-  protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
-  count             = "${var.logging_enabled && var.enable_http_tcp_listener_redirect ? 0 : var.http_tcp_listeners_count}"
+resource "aws_lb_listener" "frontend_http_tcp_forward" {
+  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, list("")), 0)}"
+  port              = "${lookup(var.http_tcp_listeners_forward[count.index], "port")}"
+  protocol          = "${lookup(var.http_tcp_listeners_forward[count.index], "protocol")}"
+  count             = "${var.logging_enabled ? var.http_tcp_listeners_forward_count : 0}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
-    type             = "${lookup(var.http_tcp_listeners[count.index], "default_action_type", "forward")}"
+    target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners_forward[count.index], "target_group_index", 0)]}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "frontend_http_tcp_redirect" {
+  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, list("")), 0)}"
+  port              = "${lookup(var.http_tcp_listeners_redirect[count.index], "port")}"
+  protocol          = "${lookup(var.http_tcp_listeners_redirect[count.index], "protocol")}"
+  count             = "${var.logging_enabled ? var.http_tcp_listeners_redirect_count : 0}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners_redirect[count.index], "target_group_index", 0)]}"
+    type             = "redirect"
 
     redirect {
-      count       = "${lookup(var.http_tcp_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
-      host        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_host", lookup(var.http_tcp_listeners_redirect_defaults, "host"))}"
-      path        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_path", lookup(var.http_tcp_listeners_redirect_defaults, "path"))}"
-      port        = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_port", lookup(var.http_tcp_listeners_redirect_defaults, "port"))}"
-      protocol    = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_protocol", lookup(var.http_tcp_listeners_redirect_defaults, "protocol"))}"
-      query       = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_query", lookup(var.http_tcp_listeners_redirect_defaults, "query"))}"
-      status_code = "${lookup(var.http_tcp_listeners[count.index], "default_action_redirect_status_code", lookup(var.http_tcp_listeners_redirect_defaults, "status_code"))}"
+      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))}"
+      path        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
+      port        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
+      protocol    = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"
+      query       = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_query", lookup(var.default_action_redirect_defaults, "query"))}"
+      status_code = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_status_code", lookup(var.default_action_redirect_defaults, "status_code"))}"
     }
   }
 }
 
 resource "aws_lb_listener" "frontend_https" {
-  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
+  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application.*.arn), 0)}"
   port              = "${lookup(var.https_listeners[count.index], "port")}"
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"
@@ -104,17 +115,7 @@ resource "aws_lb_listener" "frontend_https" {
 
   default_action {
     target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
-    type             = "${lookup(var.https_listeners[count.index], "default_action_type", "forward")}"
-
-    redirect {
-      count       = "${lookup(var.https_listeners[count.index], "default_action_type") == "redirect" ? 1 : 0}"
-      host        = "${lookup(var.https_listeners[count.index], "default_action_redirect_host", lookup(var.default_action_redirect_defaults, "host"))}"
-      path        = "${lookup(var.https_listeners[count.index], "default_action_redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
-      port        = "${lookup(var.https_listeners[count.index], "default_action_redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
-      protocol    = "${lookup(var.https_listeners[count.index], "default_action_redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"
-      query       = "${lookup(var.https_listeners[count.index], "default_action_redirect_query", lookup(var.default_action_redirect_defaults, "query"))}"
-      status_code = "${lookup(var.https_listeners[count.index], "default_action_redirect_status_code", lookup(var.default_action_redirect_defaults, "status_code"))}"
-    }
+    type             = "forward"
   }
 }
 

--- a/examples/alb_test_fixture/locals.tf
+++ b/examples/alb_test_fixture/locals.tf
@@ -22,9 +22,9 @@ locals {
                         ),
   )}"
 
-  http_tcp_listeners_count = 3
+  http_tcp_listeners_forward_count = 3
 
-  http_tcp_listeners = "${list(
+  http_tcp_listeners_forward = "${list(
                             map(
                                 "port", 80,
                                 "protocol", "HTTP",

--- a/examples/alb_test_fixture/main.tf
+++ b/examples/alb_test_fixture/main.tf
@@ -89,21 +89,21 @@ resource "aws_launch_configuration" "as_conf" {
 }
 
 module "alb" {
-  source                   = "../.."
-  load_balancer_name       = "test-alb-${random_string.suffix.result}"
-  security_groups          = ["${module.security_group.this_security_group_id}"]
-  logging_enabled          = true
-  log_bucket_name          = "${aws_s3_bucket.log_bucket.id}"
-  log_location_prefix      = "${var.log_location_prefix}"
-  subnets                  = "${module.vpc.public_subnets}"
-  tags                     = "${local.tags}"
-  vpc_id                   = "${module.vpc.vpc_id}"
-  https_listeners          = "${local.https_listeners}"
-  https_listeners_count    = "${local.https_listeners_count}"
-  http_tcp_listeners       = "${local.http_tcp_listeners}"
-  http_tcp_listeners_count = "${local.http_tcp_listeners_count}"
-  target_groups            = "${local.target_groups}"
-  target_groups_count      = "${local.target_groups_count}"
-  extra_ssl_certs          = "${local.extra_ssl_certs}"
-  extra_ssl_certs_count    = "${local.extra_ssl_certs_count}"
+  source                           = "../.."
+  load_balancer_name               = "test-alb-${random_string.suffix.result}"
+  security_groups                  = ["${module.security_group.this_security_group_id}"]
+  logging_enabled                  = true
+  log_bucket_name                  = "${aws_s3_bucket.log_bucket.id}"
+  log_location_prefix              = "${var.log_location_prefix}"
+  subnets                          = "${module.vpc.public_subnets}"
+  tags                             = "${local.tags}"
+  vpc_id                           = "${module.vpc.vpc_id}"
+  https_listeners                  = "${local.https_listeners}"
+  https_listeners_count            = "${local.https_listeners_count}"
+  http_tcp_listeners_forward       = "${local.http_tcp_listeners_forward}"
+  http_tcp_listeners_forward_count = "${local.http_tcp_listeners_forward_count}"
+  target_groups                    = "${local.target_groups}"
+  target_groups_count              = "${local.target_groups_count}"
+  extra_ssl_certs                  = "${local.extra_ssl_certs}"
+  extra_ssl_certs_count            = "${local.extra_ssl_certs_count}"
 }

--- a/examples/alb_test_fixture/outputs.tf
+++ b/examples/alb_test_fixture/outputs.tf
@@ -6,8 +6,8 @@ output "account_id" {
   value = "${data.aws_caller_identity.current.account_id}"
 }
 
-output "http_tcp_listener_arns" {
-  value = "${module.alb.http_tcp_listener_arns}"
+output "http_tcp_listener_forward_arns" {
+  value = "${module.alb.http_tcp_listener_forward_arns}"
 }
 
 output "https_listener_arns" {
@@ -38,6 +38,6 @@ output "https_listeners_count" {
   value = "${local.https_listeners_count}"
 }
 
-output "http_tcp_listeners_count" {
-  value = "${local.http_tcp_listeners_count}"
+output "http_tcp_listeners_forward_count" {
+  value = "${local.http_tcp_listeners_forward_count}"
 }

--- a/main.tf
+++ b/main.tf
@@ -54,8 +54,8 @@ Balancer (ALB) running over HTTP/HTTPS. Available through the [Terraform registr
 *   vpc_id                        = "vpc-abcde012"
 *   https_listeners               = "${list(map("certificate_arn", "arn:aws:iam::123456789012:server-certificate/test_cert-123456789012", "port", 443))}"
 *   https_listeners_count         = "1"
-*   http_tcp_listeners            = "${list(map("port", "80", "protocol", "HTTP"))}"
-*   http_tcp_listeners_count      = "1"
+*   http_tcp_listeners_forward            = "${list(map("port", "80", "protocol", "HTTP"))}"
+*   http_tcp_listeners_forward_count      = "1"
 *   target_groups                 = "${list(map("name", "foo", "backend_protocol", "HTTP", "backend_port", "80"))}"
 *   target_groups_count           = "1"
 * }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,14 +3,24 @@ output "dns_name" {
   value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name), 0)}"
 }
 
-output "http_tcp_listener_arns" {
-  description = "The ARN of the TCP and HTTP load balancer listeners created."
-  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp.*.arn, aws_lb_listener.frontend_http_tcp_no_logs.*.arn), 0, var.http_tcp_listeners_count)}"
+output "http_tcp_listener_forward_arns" {
+  description = "The ARN of the TCP and HTTP load balancer listeners with forward default action created."
+  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp_forward.*.arn, aws_lb_listener.frontend_http_tcp_forward_no_logs.*.arn), 0, var.http_tcp_listeners_forward_count)}"
 }
 
-output "http_tcp_listener_ids" {
-  description = "The IDs of the TCP and HTTP load balancer listeners created."
-  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp.*.id, aws_lb_listener.frontend_http_tcp_no_logs.*.id), 0, var.http_tcp_listeners_count)}"
+output "http_tcp_listener_forward_ids" {
+  description = "The IDs of the TCP and HTTP load balancer listeners with forward default action created."
+  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp_forward.*.id, aws_lb_listener.frontend_http_tcp_forward_no_logs.*.id), 0, var.http_tcp_listeners_forward_count)}"
+}
+
+output "http_tcp_listener_redirect_arns" {
+  description = "The ARN of the TCP and HTTP load balancer listeners with redirect default action created."
+  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp_redirect.*.arn, aws_lb_listener.frontend_http_tcp_redirect_no_logs.*.arn), 0, var.http_tcp_listeners_redirect_count)}"
+}
+
+output "http_tcp_listener_redirect_ids" {
+  description = "The IDs of the TCP and HTTP load balancer listeners with redirect default action created."
+  value       = "${slice(concat(aws_lb_listener.frontend_http_tcp_redirect.*.id, aws_lb_listener.frontend_http_tcp_redirect_no_logs.*.id), 0, var.http_tcp_listeners_redirect_count)}"
 }
 
 output "https_listener_arns" {

--- a/test/integration/default/setup.rb
+++ b/test/integration/default/setup.rb
@@ -3,10 +3,10 @@
 # rubocop:disable LineLength
 state_file = 'terraform.tfstate.d/kitchen-terraform-default-aws/terraform.tfstate'
 tf_state = JSON.parse(File.open(state_file).read)
-@http_tcp_listener_arns = tf_state['modules'][0]['outputs']['http_tcp_listener_arns']['value']
+@http_tcp_listener_forward_arns = tf_state['modules'][0]['outputs']['http_tcp_listener_forward_arns']['value']
 @https_listener_arns = tf_state['modules'][0]['outputs']['https_listener_arns']['value']
 @target_group_arns = tf_state['modules'][0]['outputs']['target_group_arns']['value']
-@http_tcp_listeners_count = tf_state['modules'][0]['outputs']['http_tcp_listeners_count']['value']
+@http_tcp_listeners_forward_count = tf_state['modules'][0]['outputs']['http_tcp_listeners_forward_count']['value']
 @https_listeners_count = tf_state['modules'][0]['outputs']['https_listeners_count']['value']
 @target_groups_count = tf_state['modules'][0]['outputs']['target_groups_count']['value']
 # rubocop:enable LineLength
@@ -17,5 +17,5 @@ ENV['AWS_REGION'] = @region
 VPC_ID = tf_state['modules'][0]['outputs']['vpc_id']['value']
 SECURITY_GROUP_ID = tf_state['modules'][0]['outputs']['sg_id']['value']
 @count_cases = [[@target_group_arns, @target_groups_count],
-               [@http_tcp_listener_arns, @http_tcp_listeners_count],
+               [@http_tcp_listener_forward_arns, @http_tcp_listeners_forward_count],
                [@https_listener_arns, @https_listeners_count]]

--- a/test/integration/default/test_alb.rb
+++ b/test/integration/default/test_alb.rb
@@ -48,7 +48,7 @@ end
   end
 end
 
-@http_tcp_listener_arns.each do |listener|
+@http_tcp_listener_forward_arns.each do |listener|
   describe alb_listener(listener) do
     it { should exist }
     its(:protocol) { should eq 'HTTP' }

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,20 @@ variable "target_groups_defaults" {
   }
 }
 
+variable "default_action_redirect_defaults" {
+  description = "Default values for default action redirect block as defined by the list of maps."
+  type        = "map"
+
+  default = {
+    "host"        = "#{host}"
+    "path"        = "#{path}"
+    "port"        = "#{port}"
+    "protocol"    = "#{protocol}"
+    "query"       = "#{query}"
+    "status_code" = "HTTP_301"
+  }
+}
+
 variable "vpc_id" {
   description = "VPC id where the load balancer and other resources will be deployed."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,14 +35,25 @@ variable "https_listeners_count" {
   default     = 0
 }
 
-variable "http_tcp_listeners" {
-  description = "A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0)"
+variable "http_tcp_listeners_forward" {
+  description = "A list of maps describing the HTTP listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0)"
   type        = "list"
   default     = []
 }
 
-variable "http_tcp_listeners_count" {
-  description = "A manually provided count/length of the http_tcp_listeners list of maps since the list cannot be computed."
+variable "http_tcp_listeners_forward_count" {
+  description = "A manually provided count/length of the http_tcp_listeners_forward list of maps since the list cannot be computed."
+  default     = 0
+}
+
+variable "http_tcp_listeners_redirect" {
+  description = "A list of maps describing the HTTP listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0)"
+  type        = "list"
+  default     = []
+}
+
+variable "http_tcp_listeners_redirect_count" {
+  description = "A manually provided count/length of the http_tcp_listeners_redirect list of maps since the list cannot be computed."
   default     = 0
 }
 
@@ -151,7 +162,7 @@ variable "default_action_redirect_defaults" {
 
   default = {
     "host"        = "#{host}"
-    "path"        = "#{path}"
+    "path"        = "/#{path}"
     "port"        = "#{port}"
     "protocol"    = "#{protocol}"
     "query"       = "#{query}"


### PR DESCRIPTION
Hi,

With the actual version the module only allow forward listeners type. Recently AWS added redirect listeners type. For example we can now redirect HTTP to HTTPS directly from lb resources.

I seperated `aws_lb_listeners` by default action type, one for forward and one for redirect but only on http_tcp listeners.

- Before `frontend_http_tcp`
- After `frontend_http_tcp_forward` & `frontend_http_tcp_redirect`

It breaks actual use of the module since the resource `aws_lb_listener.frontend_http_tcp` doesn't exist anymore.

Documentation have been updated as well as tests.
Terraform AWS provider `1.33.0` is required to use this feature.