### PR TITLE
Add create_alb variable to control resource creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| create\_alb | Controls if the ALB should be created | string | `true` | no |
 | enable\_cross\_zone\_load\_balancing | Indicates whether cross zone load balancing should be enabled in application load balancers. | string | `false` | no |
 | enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | string | `false` | no |
 | enable\_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | string | `true` | no |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "dns_name" {
   description = "The DNS name of the load balancer."
-  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name), 0)}"
+  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name, list("")), 0)}"
 }
 
 output "http_tcp_listener_arns" {
@@ -25,17 +25,17 @@ output "https_listener_ids" {
 
 output "load_balancer_arn_suffix" {
   description = "ARN suffix of our load balancer - can be used with CloudWatch."
-  value       = "${element(concat(aws_lb.application.*.arn_suffix, aws_lb.application_no_logs.*.arn_suffix), 0)}"
+  value       = "${element(concat(aws_lb.application.*.arn_suffix, aws_lb.application_no_logs.*.arn_suffix, list("")), 0)}"
 }
 
 output "load_balancer_id" {
   description = "The ID and ARN of the load balancer we created."
-  value       = "${element(concat(aws_lb.application.*.id, aws_lb.application_no_logs.*.id), 0)}"
+  value       = "${element(concat(aws_lb.application.*.id, aws_lb.application_no_logs.*.id, list("")), 0)}"
 }
 
 output "load_balancer_zone_id" {
   description = "The zone_id of the load balancer to assist with creating DNS records."
-  value       = "${element(concat(aws_lb.application.*.zone_id, aws_lb.application_no_logs.*.zone_id), 0)}"
+  value       = "${element(concat(aws_lb.application.*.zone_id, aws_lb.application_no_logs.*.zone_id, list("")), 0)}"
 }
 
 output "target_group_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "create_alb" {
+  description = "Controls if the ALB should be created"
+  default     = true
+}
+
 variable "enable_deletion_protection" {
   description = "If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false."
   default     = false


### PR DESCRIPTION
# PR o'clock

## Description

Add a variable named `create_alb` to control whether or not this module will actually create ALB resources. This enables the module to be used conditionally. If `create_alb` is set to false, then the count of resources within will be 0, causing them to be not created, or removed if they already exist.

Terraform doesn't support the count parameter for modules (hashicorp/terraform#953). A variable is needed for module users to enable/disable the module.

The `create_alb` variable is intended to mirror the intent of the `create_vpc` variable in the `terraform-aws-vpc` module.

Closes #77 

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above