### PR TITLE
Add slow_start option to target_group defs

### DIFF
--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -27,6 +27,7 @@ resource "aws_lb_target_group" "main_no_logs" {
   protocol             = "${upper(lookup(var.target_groups[count.index], "backend_protocol"))}"
   deregistration_delay = "${lookup(var.target_groups[count.index], "deregistration_delay", lookup(var.target_groups_defaults, "deregistration_delay"))}"
   target_type          = "${lookup(var.target_groups[count.index], "target_type", lookup(var.target_groups_defaults, "target_type"))}"
+  slow_start           = "${lookup(var.target_groups[count.index], "slow_start", lookup(var.target_groups_defaults, "slow_start"))}"
 
   health_check {
     interval            = "${lookup(var.target_groups[count.index], "health_check_interval", lookup(var.target_groups_defaults, "health_check_interval"))}"

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -33,6 +33,7 @@ resource "aws_lb_target_group" "main" {
   protocol             = "${upper(lookup(var.target_groups[count.index], "backend_protocol"))}"
   deregistration_delay = "${lookup(var.target_groups[count.index], "deregistration_delay", lookup(var.target_groups_defaults, "deregistration_delay"))}"
   target_type          = "${lookup(var.target_groups[count.index], "target_type", lookup(var.target_groups_defaults, "target_type"))}"
+  slow_start           = "${lookup(var.target_groups[count.index], "slow_start", lookup(var.target_groups_defaults, "slow_start"))}"
 
   health_check {
     interval            = "${lookup(var.target_groups[count.index], "health_check_interval", lookup(var.target_groups_defaults, "health_check_interval"))}"

--- a/test/integration/default/test_alb.rb
+++ b/test/integration/default/test_alb.rb
@@ -37,6 +37,7 @@ end
     its(:unhealthy_threshold_count) { should eq 3 }
     its(:target_type) { should eq 'instance' }
     its(:health_check_port) { should eq 'traffic-port' }
+    its(:slow_start) { should eq 0 }
   end
 end
 

--- a/variables.tf
+++ b/variables.tf
@@ -133,6 +133,7 @@ variable "target_groups_defaults" {
   default = {
     "cookie_duration"                  = 86400
     "deregistration_delay"             = 300
+    "slow_start"                       = 0
     "health_check_interval"            = 10
     "health_check_healthy_threshold"   = 3
     "health_check_path"                = "/"


### PR DESCRIPTION
# PR o'clock

## Description

This adds support for `slow_start` to the target_groups which fixes #86 

### Checklist

* [X] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [X] Tests for the changes have been added and passing (for bug fixes/features)
* [X] Test results are pasted in this PR (in lieu of CI)
* [X] Docs have been added/updated (for bug fixes/features)
* [X] Any breaking changes are noted in the description above
