### PR TITLE
Added load_balancer_arn to the output list

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,11 @@ output "load_balancer_id" {
   value       = "${element(concat(aws_lb.application.*.id, aws_lb.application_no_logs.*.id), 0)}"
 }
 
+output "load_balancer_arn" {
+  description = "The ID and ARN of the load balancer we created."
+  value       = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
+}
+
 output "load_balancer_zone_id" {
   description = "The zone_id of the load balancer to assist with creating DNS records."
   value       = "${element(concat(aws_lb.application.*.zone_id, aws_lb.application_no_logs.*.zone_id), 0)}"


### PR DESCRIPTION
# PR o'clock

## Description

I added load_balancer_arn to the list of outputs. I've had to add it for my environment because I create the listener outside the module for some projects, as they use a fixed response as default, which isn't available in the module. I figured it might be useful for others who need to pull out the ARN of the newly created load balancer.

### Checklist

* [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
