### PR TITLE
Fix element lookup in `dns_name` output variable

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "dns_name" {
   description = "The DNS name of the load balancer."
-  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name), 0)}"
+  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name, list("")), 0)}"
 }
 
 output "http_tcp_listener_arns" {


### PR DESCRIPTION
# PR o'clock

## Description

This pull request modifies the `dns_name` output variable to include an empty `list("")` argument to the `concat` function. The reason for submitting this pull request is because of an upstream issue experienced using version `3.5.0`:

```
* module.alb.output.dns_name: element: element() may not be used with an empty list in:

${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name), 0)}
```

Please explain the changes you made here and link to any relevant issues.

```diff
 output "dns_name" {
   description = "The DNS name of the load balancer."
-  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name), 0)}"
+  value       = "${element(concat(aws_lb.application.*.dns_name, aws_lb.application_no_logs.*.dns_name, list("")), 0)}"
 }
```

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] ~Tests for the changes have been added and passing (for bug fixes/features)~
* [x] Test results are pasted in this PR (in lieu of CI)
* [ ] ~Docs have been added/updated (for bug fixes/features)~
* [ ] ~Any breaking changes are noted in the description above~
