### PR TITLE
Remove --error-with-issues option on tflint as it is now default and removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 - terraform init
 - terraform fmt -check=true
 - terraform validate -var "region=${AWS_REGION}" -var "subnets=[]" -var "vpc_id=vpc-abcde012" -var "load_balancer_name=my-lb" -var "log_bucket_name=my-log-bucket" -var "security_groups=[]"
-- docker run --rm -v $(pwd):/app/ --workdir=/app/ -t wata727/tflint --error-with-issues
+- docker run --rm -v $(pwd):/app/ --workdir=/app/ -t wata727/tflint
 - cd examples/alb_test_fixture
 - terraform init
 - terraform fmt -check=true


### PR DESCRIPTION
# PR o'clock

## Description

Fixing the failing build as a result of an option for tflint as it was both set as the default and removed as an option.

https://travis-ci.org/terraform-aws-modules/terraform-aws-alb