### PR TITLE
Adding target group level tagging

### DIFF
--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -108,6 +108,7 @@ resource "aws_lb_target_group" "main_no_logs" {
 
   tags = merge(
     var.tags,
+    length(var.target_groups_tags) > 0 ? var.target_groups_tags[count.index] : {},
     {
       "Name" = var.target_groups[count.index]["name"]
     },

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -113,6 +113,7 @@ resource "aws_lb_target_group" "main" {
 
   tags = merge(
     var.tags,
+    length(var.target_groups_tags) > 0 ? var.target_groups_tags[count.index] : {},
     {
       "Name" = var.target_groups[count.index]["name"]
     },

--- a/examples/alb_test_fixture/README.md
+++ b/examples/alb_test_fixture/README.md
@@ -136,6 +136,7 @@ The following IAM policy is the minimum needed to execute the module from the te
 | sg\_id |  |
 | target\_group\_arns |  |
 | target\_groups\_count |  |
+| target\_groups\_tags |  |
 | vpc\_id |  |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/alb_test_fixture/locals.tf
+++ b/examples/alb_test_fixture/locals.tf
@@ -59,6 +59,15 @@ locals {
     },
   ]
 
+  target_groups_tags = [
+    {
+      "HostGroup" = "Foo"
+    },
+    {
+      "HostGroup" = "Bar"
+    }
+  ]
+
   extra_ssl_certs_count = 4
 
   extra_ssl_certs = [

--- a/examples/alb_test_fixture/main.tf
+++ b/examples/alb_test_fixture/main.tf
@@ -99,6 +99,7 @@ module "alb" {
   http_tcp_listeners_count = local.http_tcp_listeners_count
   target_groups            = local.target_groups
   target_groups_count      = local.target_groups_count
+  target_groups_tags       = local.target_groups_tags
   extra_ssl_certs          = local.extra_ssl_certs
   extra_ssl_certs_count    = local.extra_ssl_certs_count
 }

--- a/examples/alb_test_fixture/outputs.tf
+++ b/examples/alb_test_fixture/outputs.tf
@@ -42,3 +42,7 @@ output "http_tcp_listeners_count" {
   value = local.http_tcp_listeners_count
 }
 
+output "target_groups_tags" {
+  value = local.target_groups_tags
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,12 @@ variable "target_groups" {
   default     = []
 }
 
+variable "target_groups_tags" {
+  description = "A list of maps containing key/value pairs that have the target group tags. Order of these maps is important and the index of these are to be referenced in target group definitions."
+  type        = list(map(string))
+  default     = []
+}
+
 variable "target_groups_count" {
   description = "A manually provided count/length of the target_groups list of maps since the list cannot be computed."
   type        = number


### PR DESCRIPTION
# PR o'clock

## Description

Sometimes it's necessary to tag target groups at the target group level, rather than just inheriting from the parent ALB. 

For example, if we have an ALB for all our QA services, the target groups underneath are tagged with what host group they are. This is useful for if you have heterogenous services running under the same LB. In our case, we have several dev instances that are tagged with their `HostGroup : dev` and `Index: n` for easy filtering on which target groups are available to stick an instance under. I've made these changes for our local fork, but since we'd like to keep upstream changes and avoid conflicts, I figured making this PR would be a good idea. Let me know if this is something you'd like to see in the module!

Example:
```
 "id": "arn:aws:elasticloadbalancing:us-west-2:794037559540:targetgroup/bar/2e899aec2bc4367c",
             "lambda_multi_value_headers_enabled": false,
             "name": "bar",
             "name_prefix": null,
             "port": 8080,
             "protocol": "HTTP",
             "proxy_protocol_v2": false,
             "slow_start": 100,
             "stickiness": [
               {
                 "cookie_duration": 86400,
                 "enabled": true,
                 "type": "lb_cookie"
               }
             ],
             "tags": {
               "Environment": "test",
               "GithubOrg": "terraform-aws-modules",
               "GithubRepo": "tf-aws-alb",
               "HostGroup": "Bar",
               "Name": "bar",
               "Workspace": "default"
             },
             "target_type": "instance",
```

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [x] Test results are pasted in this PR (in lieu of CI)
* [x] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above

#### Testing notes
Test: https://gist.github.com/snoozan/9d6c494cdfdab8f8427fdb031bf957a8
The RSpec framework being used doesn't spec out tags at the target group level. This could be added to the library, but as of right now, no spec tests were written because of the lack of target group tags. See: https://github.com/k1LoW/awspec/commit/a3e729e8edc0ee1fa9f16bbae394ba12f777aa9c#diff-1acc82be899fcf02f9d1974a4850e3f8