### PR TITLE
Prevent error when reference to http_tcp_listeners or target_groups a…

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,7 +18,10 @@ output "http_tcp_listener_arns" {
       aws_lb_listener.frontend_http_tcp_no_logs.*.arn,
     ),
     0,
-    var.http_tcp_listeners_count,
+    length(concat(
+      aws_lb_listener.frontend_http_tcp.*.arn,
+      aws_lb_listener.frontend_http_tcp_no_logs.*.arn,
+    )) != 0 ? var.http_tcp_listeners_count : 0,
   )
 }
 
@@ -30,7 +33,10 @@ output "http_tcp_listener_ids" {
       aws_lb_listener.frontend_http_tcp_no_logs.*.id,
     ),
     0,
-    var.http_tcp_listeners_count,
+    length(concat(
+      aws_lb_listener.frontend_http_tcp.*.id,
+      aws_lb_listener.frontend_http_tcp_no_logs.*.id,
+    )) != 0 ? var.http_tcp_listeners_count : 0,
   )
 }
 
@@ -42,7 +48,10 @@ output "https_listener_arns" {
       aws_lb_listener.frontend_https_no_logs.*.arn,
     ),
     0,
-    var.https_listeners_count,
+    length(concat(
+      aws_lb_listener.frontend_https.*.arn,
+      aws_lb_listener.frontend_https_no_logs.*.arn,
+    )) != 0 ? var.http_tcp_listeners_count : 0,
   )
 }
 
@@ -54,7 +63,10 @@ output "https_listener_ids" {
       aws_lb_listener.frontend_https_no_logs.*.id,
     ),
     0,
-    var.https_listeners_count,
+    length(concat(
+      aws_lb_listener.frontend_https.*.id,
+      aws_lb_listener.frontend_https_no_logs.*.id,
+    )) != 0 ? var.http_tcp_listeners_count : 0,
   )
 }
 
@@ -102,7 +114,10 @@ output "target_group_arns" {
       aws_lb_target_group.main_no_logs.*.arn,
     ),
     0,
-    var.target_groups_count,
+    length(concat(
+      aws_lb_target_group.main.*.arn,
+      aws_lb_target_group.main_no_logs.*.arn,
+    )) != 0 ? var.target_groups_count : 0,
   )
 }
 
@@ -114,7 +129,10 @@ output "target_group_arn_suffixes" {
       aws_lb_target_group.main_no_logs.*.arn_suffix,
     ),
     0,
-    var.target_groups_count,
+    length(concat(
+      aws_lb_target_group.main.*.arn_suffix,
+      aws_lb_target_group.main_no_logs.*.arn_suffix,
+    )) != 0 ? var.target_groups_count : 0,
   )
 }
 
@@ -126,7 +144,10 @@ output "target_group_names" {
       aws_lb_target_group.main_no_logs.*.name,
     ),
     0,
-    var.target_groups_count,
+    length(concat(
+      aws_lb_target_group.main.*.name,
+      aws_lb_target_group.main_no_logs.*.name,
+    )) != 0 ? var.target_groups_count : 0,
   )
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

When destroy `Autoscaling Group` referencing to `Target Groups` ( `Target Groups` were destroyed successfully before ), the error will show up like: 

```
Error: Invalid function argument

  on ../../modules/terraform-aws-alb/outputs.tf line 105, in output "target_group_arns":
  99:
 100:
 101:
 102:
 103:
 104:
 105:     var.target_groups_count,
 106:
    |----------------
    | var.target_groups_count is 1

Invalid value for "end_index" parameter: end index must not be greater than
the length of the list. 
```

Just add condition to check if the list is empty or not. For example:
```
output "target_group_arn_suffixes" {
  description = "ARN suffixes of our target groups - can be used with CloudWatch."
  value = slice(
    concat(
      aws_lb_target_group.main.*.arn_suffix,
      aws_lb_target_group.main_no_logs.*.arn_suffix,
    ),
    0,
    length(concat(
      aws_lb_target_group.main.*.arn_suffix,
      aws_lb_target_group.main_no_logs.*.arn_suffix,
    )) != 0 ? var.target_groups_count : 0,
  )
}
```

If `Target Groups` are already destroyed, the `end_index` will be 0. 

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
