### PR TITLE
Set correct TG for listeners (fixed #119)

### DIFF
--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -121,19 +121,19 @@ resource "aws_lb_target_group" "main_no_logs" {
 }
 
 resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
-  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), 0)
+  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), count.index)
   port              = var.http_tcp_listeners[count.index]["port"]
   protocol          = var.http_tcp_listeners[count.index]["protocol"]
   count             = var.create_alb && false == var.logging_enabled ? var.http_tcp_listeners_count : 0
 
   default_action {
-    target_group_arn = aws_lb_target_group.main_no_logs[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)].id
+    target_group_arn = aws_lb_target_group.main_no_logs[lookup(var.http_tcp_listeners[count.index], "target_group_index", count.index)].id
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "frontend_https_no_logs" {
-  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), 0)
+  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), count.index)
   port              = var.https_listeners[count.index]["port"]
   protocol          = "HTTPS"
   certificate_arn   = var.https_listeners[count.index]["certificate_arn"]
@@ -145,7 +145,7 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
   count = var.create_alb && false == var.logging_enabled ? var.https_listeners_count : 0
 
   default_action {
-    target_group_arn = aws_lb_target_group.main_no_logs[lookup(var.https_listeners[count.index], "target_group_index", 0)].id
+    target_group_arn = aws_lb_target_group.main_no_logs[lookup(var.https_listeners[count.index], "target_group_index", count.index)].id
     type             = "forward"
   }
 }

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -121,7 +121,7 @@ resource "aws_lb_target_group" "main_no_logs" {
 }
 
 resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
-  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), count.index)
+  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), 0)
   port              = var.http_tcp_listeners[count.index]["port"]
   protocol          = var.http_tcp_listeners[count.index]["protocol"]
   count             = var.create_alb && false == var.logging_enabled ? var.http_tcp_listeners_count : 0
@@ -133,7 +133,7 @@ resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
 }
 
 resource "aws_lb_listener" "frontend_https_no_logs" {
-  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), count.index)
+  load_balancer_arn = element(concat(aws_lb.application_no_logs.*.arn, [""]), 0)
   port              = var.https_listeners[count.index]["port"]
   protocol          = "HTTPS"
   certificate_arn   = var.https_listeners[count.index]["certificate_arn"]

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -128,7 +128,7 @@ resource "aws_lb_target_group" "main" {
 resource "aws_lb_listener" "frontend_http_tcp" {
   load_balancer_arn = element(
     concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn),
-    count.index,
+    0,
   )
   port     = var.http_tcp_listeners[count.index]["port"]
   protocol = var.http_tcp_listeners[count.index]["protocol"]
@@ -143,7 +143,7 @@ resource "aws_lb_listener" "frontend_http_tcp" {
 resource "aws_lb_listener" "frontend_https" {
   load_balancer_arn = element(
     concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn),
-    count.index,
+    0,
   )
   port            = var.https_listeners[count.index]["port"]
   protocol        = "HTTPS"

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -128,14 +128,14 @@ resource "aws_lb_target_group" "main" {
 resource "aws_lb_listener" "frontend_http_tcp" {
   load_balancer_arn = element(
     concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn),
-    0,
+    count.index,
   )
   port     = var.http_tcp_listeners[count.index]["port"]
   protocol = var.http_tcp_listeners[count.index]["protocol"]
   count    = var.create_alb && var.logging_enabled ? var.http_tcp_listeners_count : 0
 
   default_action {
-    target_group_arn = aws_lb_target_group.main[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)].id
+    target_group_arn = aws_lb_target_group.main[lookup(var.http_tcp_listeners[count.index], "target_group_index", count.index)].id
     type             = "forward"
   }
 }
@@ -143,7 +143,7 @@ resource "aws_lb_listener" "frontend_http_tcp" {
 resource "aws_lb_listener" "frontend_https" {
   load_balancer_arn = element(
     concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn),
-    0,
+    count.index,
   )
   port            = var.https_listeners[count.index]["port"]
   protocol        = "HTTPS"
@@ -156,7 +156,7 @@ resource "aws_lb_listener" "frontend_https" {
   count = var.create_alb && var.logging_enabled ? var.https_listeners_count : 0
 
   default_action {
-    target_group_arn = aws_lb_target_group.main[lookup(var.https_listeners[count.index], "target_group_index", 0)].id
+    target_group_arn = aws_lb_target_group.main[lookup(var.https_listeners[count.index], "target_group_index", count.index)].id
     type             = "forward"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

When you specify two ALB listeners (http-80 and http-8080) and two Target Groups (tg-80 and tg-8080), you get the following mapping:

```
http-80 -> tg-80
http-8080 -> tg-80
```

and instead of the expected:

```
http-80 -> tg-80
http-8080 -> tg-8080
```

https://github.com/terraform-aws-modules/terraform-aws-alb/issues/119

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [x] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
