### PR TITLE
Set correct TG for listeners for Terraform 0.11 (fixed #119)

### DIFF
--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -56,7 +56,7 @@ resource "aws_lb_target_group" "main_no_logs" {
 }
 
 resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
-  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), count.index)}"
+  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
   count             = "${var.create_alb && !var.logging_enabled ? var.http_tcp_listeners_count : 0}"
@@ -68,7 +68,7 @@ resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
 }
 
 resource "aws_lb_listener" "frontend_https_no_logs" {
-  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), count.index)}"
+  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
   port              = "${lookup(var.https_listeners[count.index], "port")}"
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -56,19 +56,19 @@ resource "aws_lb_target_group" "main_no_logs" {
 }
 
 resource "aws_lb_listener" "frontend_http_tcp_no_logs" {
-  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
+  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), count.index)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
   count             = "${var.create_alb && !var.logging_enabled ? var.http_tcp_listeners_count : 0}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
+    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", count.index)]}"
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "frontend_https_no_logs" {
-  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), 0)}"
+  load_balancer_arn = "${element(concat(aws_lb.application_no_logs.*.arn, list("")), count.index)}"
   port              = "${lookup(var.https_listeners[count.index], "port")}"
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"
@@ -76,7 +76,7 @@ resource "aws_lb_listener" "frontend_https_no_logs" {
   count             = "${var.create_alb && !var.logging_enabled ? var.https_listeners_count : 0}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
+    target_group_arn = "${aws_lb_target_group.main_no_logs.*.id[lookup(var.https_listeners[count.index], "target_group_index", count.index)]}"
     type             = "forward"
   }
 }

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -62,19 +62,19 @@ resource "aws_lb_target_group" "main" {
 }
 
 resource "aws_lb_listener" "frontend_http_tcp" {
-  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
+  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), count.index)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
   count             = "${var.create_alb && var.logging_enabled ? var.http_tcp_listeners_count : 0}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", 0)]}"
+    target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.http_tcp_listeners[count.index], "target_group_index", count.index)]}"
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "frontend_https" {
-  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
+  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), count.index)}"
   port              = "${lookup(var.https_listeners[count.index], "port")}"
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"
@@ -82,7 +82,7 @@ resource "aws_lb_listener" "frontend_https" {
   count             = "${var.create_alb && var.logging_enabled ? var.https_listeners_count : 0}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.https_listeners[count.index], "target_group_index", 0)]}"
+    target_group_arn = "${aws_lb_target_group.main.*.id[lookup(var.https_listeners[count.index], "target_group_index", count.index)]}"
     type             = "forward"
   }
 }

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -62,7 +62,7 @@ resource "aws_lb_target_group" "main" {
 }
 
 resource "aws_lb_listener" "frontend_http_tcp" {
-  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), count.index)}"
+  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
   port              = "${lookup(var.http_tcp_listeners[count.index], "port")}"
   protocol          = "${lookup(var.http_tcp_listeners[count.index], "protocol")}"
   count             = "${var.create_alb && var.logging_enabled ? var.http_tcp_listeners_count : 0}"
@@ -74,7 +74,7 @@ resource "aws_lb_listener" "frontend_http_tcp" {
 }
 
 resource "aws_lb_listener" "frontend_https" {
-  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), count.index)}"
+  load_balancer_arn = "${element(concat(aws_lb.application.*.arn, aws_lb.application_no_logs.*.arn), 0)}"
   port              = "${lookup(var.https_listeners[count.index], "port")}"
   protocol          = "HTTPS"
   certificate_arn   = "${lookup(var.https_listeners[count.index], "certificate_arn")}"


### PR DESCRIPTION
# PR o'clock

When you specify two ALB listeners (http-80 and http-8080) and two Target Groups (tg-80 and tg-8080), you get the following mapping:

```
http-80 -> tg-80
http-8080 -> tg-80
```
and instead of the expected:
```
http-80 -> tg-80
http-8080 -> tg-8080
```

Please explain the changes you made here and link to any relevant issues.

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [x] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
