### PR TITLE
Add default security group.

### DIFF
--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "application_no_logs" {
   load_balancer_type               = "application"
   name                             = var.load_balancer_name
   internal                         = var.load_balancer_is_internal
-  security_groups                  = var.security_groups
+  security_groups                  = compact(concat(var.security_groups, [aws_security_group.default.id]))
   subnets                          = var.subnets
   idle_timeout                     = var.idle_timeout
   enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "application" {
   load_balancer_type               = "application"
   name                             = var.load_balancer_name
   internal                         = var.load_balancer_is_internal
-  security_groups                  = var.security_groups
+  security_groups                  = compact(concat(var.security_groups, [aws_security_group.default.id]))
   subnets                          = var.subnets
   idle_timeout                     = var.idle_timeout
   enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  security_group_description = "${var.security_group_description == "" ? format("%s alb security group", var.load_balancer_name) : var.security_group_description}"
+
+  target_groups_default_configs = {
+    cookie_duration                  = 86400
+    deregistration_delay             = 300
+    health_check_interval            = 10
+    health_check_healthy_threshold   = 3
+    health_check_path                = "/"
+    health_check_port                = "traffic-port"
+    health_check_timeout             = 5
+    health_check_unhealthy_threshold = 3
+    health_check_matcher             = "200-299"
+    stickiness_enabled               = true
+    target_type                      = "instance"
+    slow_start                       = 0
+  }
+
+  target_groups_defaults = "${merge(local.target_groups_default_configs, var.target_groups_defaults)}"
+}

--- a/main.tf
+++ b/main.tf
@@ -110,3 +110,8 @@ Balancer (ALB) running over HTTP/HTTPS. Available through the [Terraform registr
 
 * MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-alb/tree/master/LICENSE) for full details.
 */
+
+resource "aws_security_group" default {
+  description = local.security_group_description
+  vpc_id      = var.vpc_id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -94,6 +94,11 @@ output "load_balancer_zone_id" {
   )
 }
 
+output "sg_id" {
+  description = "The id of the default security group."
+  value       = "${aws_security_group.default.id}"
+}
+
 output "target_group_arns" {
   description = "ARNs of the target groups. Useful for passing to your Auto Scaling group."
   value = slice(

--- a/variables.tf
+++ b/variables.tf
@@ -134,9 +134,15 @@ variable "tags" {
   default     = {}
 }
 
+variable "security_group_description" {
+  description = "The description for the default security group for the alb"
+  default     = ""
+}
+
 variable "security_groups" {
   description = "The security groups to attach to the load balancer. e.g. [\"sg-edcd9784\",\"sg-edcd9785\"]"
   type        = list(string)
+  default     = [""]
 }
 
 variable "target_groups" {


### PR DESCRIPTION
# PR o'clock

## Description

Hello terraform-aws-modules. Great work you're doing here.

I added a feature to my fork and before I went any further with testing etc, I figured I'd make a pull request to get your thoughts.

The feature adds a default security group. Every alb needs a security group to function, so I thought this was a nice default to add.

Open to feedback and suggestions here.

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
