### PR TITLE
Removed unused (depracated) input variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -106,12 +106,6 @@ variable "access_logs" {
   default     = {}
 }
 
-variable "log_location_prefix" {
-  description = "S3 prefix within the log_bucket_name under which logs are stored."
-  type        = string
-  default     = ""
-}
-
 variable "subnets" {
   description = "A list of subnets to associate with the load balancer. e.g. ['subnet-1a2b3c4d','subnet-1a2b3c4e','subnet-1a2b3c4f']"
   type        = list(string)


### PR DESCRIPTION


# PR o'clock

## Description

Removed an old leftover input variable no longer used.
For backwards compatibility it could instead be used for "prefix" in access_logs variable, but personally I think that would just make it more confusing.

### Checklist

* [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [-] Tests for the changes have been added and passing (for bug fixes/features)
* [-] Test results are pasted in this PR (in lieu of CI)
* [- Not mentioned in docs] Docs have been added/updated (for bug fixes/features)
* [v] Any breaking changes are noted in the description above
