### PR TITLE
Fixed 'target_group_index' defaults in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ module "lb" {
 | enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | bool | `"false"` | no |
 | enable\_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | bool | `"true"` | no |
 | extra\_ssl\_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward). | list(map(string)) | `[]` | no |
-| http\_tcp\_listeners | A list of maps describing the HTTP listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list(map(string)) | `[]` | no |
-| https\_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, certificate_arn. Optional key/values: ssl_policy (defaults to ELBSecurityPolicy-2016-08), target_group_index (defaults to 0) | list(map(string)) | `[]` | no |
+| http\_tcp\_listeners | A list of maps describing the HTTP listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to http\_tcp\_listeners[count.index]) | list(map(string)) | `[]` | no |
+| https\_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, certificate_arn. Optional key/values: ssl_policy (defaults to ELBSecurityPolicy-2016-08), target_group_index (defaults to https\_listeners[count.index]) | list(map(string)) | `[]` | no |
 | idle\_timeout | The time in seconds that the connection is allowed to be idle. | number | `"60"` | no |
 | internal | Boolean determining if the load balancer is internal or externally facing. | bool | `"false"` | no |
 | ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are ipv4 and dualstack. | string | `"ipv4"` | no |


### PR DESCRIPTION
According to lines [main.tf:117](https://github.com/terraform-aws-modules/terraform-aws-alb/blob/aaa2ff19c7f5df0f4f114696d722c336ae1f85e0/main.tf#L117) and [main.tf:133](https://github.com/terraform-aws-modules/terraform-aws-alb/blob/aaa2ff19c7f5df0f4f114696d722c336ae1f85e0/main.tf#L133), the `target_group_index` don't default to zero, but the actual index (count.index) of the listener.

For example:
```hcl
module "alb" {
  source = "terraform-aws-modules/alb/aws"

  # ...

  http_tcp_listeners = [
    {
      port     = "80"
      protocol = "HTTP"
      # target_group_index defaults to 0
    },
    {
      port     = "8080"
      protocol = "HTTP"
      # target_group_index defaults to 1
    },
  ]
}
```

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

* [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
