### PR TITLE
Added aws_lb_target_group_attachments support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ These types of resources are supported:
 * [Load Balancer Listener](https://www.terraform.io/docs/providers/aws/r/lb_listener.html)
 * [Load Balancer Listener Certificate](https://www.terraform.io/docs/providers/aws/r/lb_listener_certificate.html)
 * [Target Group](https://www.terraform.io/docs/providers/aws/r/lb_target_group.html)
+* [Target Group Attachment](https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html)
 
 Not supported (yet):
 
 * [Load Balancer Listener default actions](https://www.terraform.io/docs/providers/aws/r/lb_listener.html) - only `forward` is supported
 * [Load Balancer Listener Rule](https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html)
-* [Target Group Attachment](https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html)
 
 ## Terraform versions
 
@@ -68,6 +68,13 @@ module "alb" {
     }
   ]
 
+  target_groups_attachments = [
+    {
+    instance_id = "i-0123456789abcdefg"
+    target_group_index = 0
+    }
+  ]
+
   tags = {
     Environment = "Test"
   }
@@ -115,6 +122,13 @@ module "nlb" {
       port               = 80
       protocol           = "TCP"
       target_group_index = 0
+    }
+  ]
+
+  target_groups_attachments = [
+    {
+    instance_id = "i-0123456789abcdefg"
+    target_group_index = 0
     }
   ]
 
@@ -180,6 +194,7 @@ module "lb" {
 | subnets | A list of subnets to associate with the load balancer. e.g. ['subnet-1a2b3c4d','subnet-1a2b3c4e','subnet-1a2b3c4f'] | list(string) | `"null"` | no |
 | tags | A map of tags to add to all resources | map(string) | `{}` | no |
 | target\_groups | A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend_protocol, backend_port. Optional key/values are in the target_groups_defaults variable. | any | `[]` | no |
+| target\_groups\_attachments | A list of maps containing key/value pairs that define the target groups attachments to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: instance_id, target_group_index. | any | `[]` | no |
 | vpc\_id | VPC id where the load balancer and other resources will be deployed. | string | `"null"` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,14 @@ resource "aws_lb_target_group" "main" {
   }
 }
 
+resource "aws_lb_target_group_attachment" "group_attachment" {
+  count = var.create_lb ? length(var.target_groups_attachments) : 0
+
+  target_group_arn = aws_lb_target_group.main[lookup(var.target_groups_attachments[count.index], "target_group_index", count.index)].arn
+  target_id        = lookup(var.target_groups_attachments[lookup(var.target_groups_attachments[count.index], "target_group_index", count.index)], "instance_id", null)
+  port             = lookup(var.target_groups[lookup(var.target_groups_attachments[count.index], "target_group_index", count.index)], "backend_port", null)
+}
+
 resource "aws_lb_listener" "frontend_http_tcp" {
   count = var.create_lb ? length(var.http_tcp_listeners) : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -148,3 +148,8 @@ variable "vpc_id" {
   default     = null
 }
 
+variable "target_groups_attachments" {
+  description = "A list of maps containing key/value pairs that define the target groups attachments to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: instance_id, target_group_index."
+  type        = any
+  default     = []
+}


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [x] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the description above
