### PR TITLE
Removed target group lifecycle policy create_before_delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,25 +161,25 @@ module "lb" {
 | enable\_cross\_zone\_load\_balancing | Indicates whether cross zone load balancing should be enabled in application load balancers. | bool | `"false"` | no |
 | enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | bool | `"false"` | no |
 | enable\_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | bool | `"true"` | no |
-| extra\_ssl\_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward). | list(map(string)) | `[]` | no |
-| http\_tcp\_listeners | A list of maps describing the HTTP listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list(map(string)) | `[]` | no |
-| https\_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, certificate_arn. Optional key/values: ssl_policy (defaults to ELBSecurityPolicy-2016-08), target_group_index (defaults to 0) | list(map(string)) | `[]` | no |
+| extra\_ssl\_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate\_arn, https\_listener\_index \(the index of the listener within https\_listeners which the cert applies toward\). | list(map(string)) | `[]` | no |
+| http\_tcp\_listeners | A list of maps describing the HTTP listeners for this ALB. Required key/values: port, protocol. Optional key/values: target\_group\_index \(defaults to 0\) | list(map(string)) | `[]` | no |
+| https\_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, certificate\_arn. Optional key/values: ssl\_policy \(defaults to ELBSecurityPolicy-2016-08\), target\_group\_index \(defaults to 0\) | list(map(string)) | `[]` | no |
 | idle\_timeout | The time in seconds that the connection is allowed to be idle. | number | `"60"` | no |
 | internal | Boolean determining if the load balancer is internal or externally facing. | bool | `"false"` | no |
 | ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are ipv4 and dualstack. | string | `"ipv4"` | no |
-| listener\_ssl\_policy\_default | The security policy if using HTTPS externally on the load balancer. [See](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html). | string | `"ELBSecurityPolicy-2016-08"` | no |
+| listener\_ssl\_policy\_default | The security policy if using HTTPS externally on the load balancer. \[See\]\(https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html\). | string | `"ELBSecurityPolicy-2016-08"` | no |
 | load\_balancer\_create\_timeout | Timeout value when creating the ALB. | string | `"10m"` | no |
 | load\_balancer\_delete\_timeout | Timeout value when deleting the ALB. | string | `"10m"` | no |
 | load\_balancer\_type | The type of load balancer to create. Possible values are application or network. | string | `"application"` | no |
 | load\_balancer\_update\_timeout | Timeout value when updating the ALB. | string | `"10m"` | no |
-| log\_location\_prefix | S3 prefix within the log_bucket_name under which logs are stored. | string | `""` | no |
+| log\_location\_prefix | S3 prefix within the log\_bucket\_name under which logs are stored. | string | `""` | no |
 | name | The resource name and Name tag of the load balancer. | string | `"null"` | no |
 | name\_prefix | The resource name prefix and Name tag of the load balancer. | string | `"null"` | no |
-| security\_groups | The security groups to attach to the load balancer. e.g. ["sg-edcd9784","sg-edcd9785"] | list(string) | `[]` | no |
+| security\_groups | The security groups to attach to the load balancer. e.g. \["sg-edcd9784","sg-edcd9785"\] | list(string) | `[]` | no |
 | subnet\_mapping | A list of subnet mapping blocks describing subnets to attach to network load balancer | list(map(string)) | `[]` | no |
-| subnets | A list of subnets to associate with the load balancer. e.g. ['subnet-1a2b3c4d','subnet-1a2b3c4e','subnet-1a2b3c4f'] | list(string) | `"null"` | no |
+| subnets | A list of subnets to associate with the load balancer. e.g. \['subnet-1a2b3c4d','subnet-1a2b3c4e','subnet-1a2b3c4f'\] | list(string) | `"null"` | no |
 | tags | A map of tags to add to all resources | map(string) | `{}` | no |
-| target\_groups | A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend_protocol, backend_port. Optional key/values are in the target_groups_defaults variable. | any | `[]` | no |
+| target\_groups | A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend\_protocol, backend\_port. Optional key/values are in the target\_groups\_defaults variable. | any | `[]` | no |
 | vpc\_id | VPC id where the load balancer and other resources will be deployed. | string | `"null"` | no |
 
 ## Outputs
@@ -197,7 +197,7 @@ module "lb" {
 | this\_lb\_arn\_suffix | ARN suffix of our load balancer - can be used with CloudWatch. |
 | this\_lb\_dns\_name | The DNS name of the load balancer. |
 | this\_lb\_id | The ID and ARN of the load balancer we created. |
-| this\_lb\_zone\_id | The zone_id of the load balancer to assist with creating DNS records. |
+| this\_lb\_zone\_id | The zone\_id of the load balancer to assist with creating DNS records. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/main.tf
+++ b/main.tf
@@ -99,10 +99,6 @@ resource "aws_lb_target_group" "main" {
   )
 
   depends_on = [aws_lb.this]
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_lb_listener" "frontend_http_tcp" {
@@ -141,4 +137,3 @@ resource "aws_lb_listener_certificate" "https_listener" {
   listener_arn    = aws_lb_listener.frontend_https[var.extra_ssl_certs[count.index]["https_listener_index"]].arn
   certificate_arn = var.extra_ssl_certs[count.index]["certificate_arn"]
 }
-


### PR DESCRIPTION
# PR o'clock

## Description

Having the create_before_destroy lifecycle policy on the target group prevents you from being able to make any changes other than the name of the target group to the target group. It will error out because it attempts to create a target group with the same name and target groups require unique names.

### Checklist

* [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
