### PR TITLE
feat: Add support for drop_invalid_header_fields

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ resource "aws_lb" "this" {
   enable_deletion_protection       = var.enable_deletion_protection
   enable_http2                     = var.enable_http2
   ip_address_type                  = var.ip_address_type
+  drop_invalid_header_fields       = var.drop_invalid_header_fields
 
   # See notes in README (ref: https://github.com/terraform-providers/terraform-provider-aws/issues/7987)
   dynamic "access_logs" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "create_lb" {
   default     = true
 }
 
+variable "drop_invalid_header_fields" {
+  description = "Indicates whether invalid header fields are dropped in application load balancers. Defaults to false."
+  type        = bool
+  default     = false
+}
+
 variable "enable_deletion_protection" {
   description = "If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false."
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12"
 
   required_providers {
-    aws = "~> 2.55"
+    aws = "~> 2.54"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.12"
 
   required_providers {
-    aws = ">= 2.54"
+    aws = "~> 2.55"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    aws = ">= 2.54"
+  }
+}


### PR DESCRIPTION
Allow to enable drop_invalid_header_fields on application load balancer

## Description
Now, it is possible to drop invalid headers if they are invalid on ALB

## Motivation and Context
Allow this AWS feature

## Breaking Changes
NA

## How Has This Been Tested?
I use this version and check option in the AWS console