### PR TITLE
feat: Add more specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,7 @@ module "lb" {
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | target\_group\_tags | A map of tags to add to all target groups | `map(string)` | `{}` | no |
 | target\_groups | A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend\_protocol, backend\_port | `any` | `[]` | no |
-| vpc\_id | VPC id where the load balancer and other resources will be deployed. | `string` | n/a | yes |
-
+| vpc\_id | VPC id where the load balancer and other resources will be deployed. | `string` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ module "lb" {
 | idle\_timeout | The time in seconds that the connection is allowed to be idle. | `number` | `60` | no |
 | internal | Boolean determining if the load balancer is internal or externally facing. | `bool` | `false` | no |
 | ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are ipv4 and dualstack. | `string` | `"ipv4"` | no |
+| lb\_tags | A map of tags to add to load balancer | `map(string)` | `{}` | no |
 | listener\_ssl\_policy\_default | The security policy if using HTTPS externally on the load balancer. [See](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html). | `string` | `"ELBSecurityPolicy-2016-08"` | no |
 | load\_balancer\_create\_timeout | Timeout value when creating the ALB. | `string` | `"10m"` | no |
 | load\_balancer\_delete\_timeout | Timeout value when deleting the ALB. | `string` | `"10m"` | no |
@@ -184,7 +185,8 @@ module "lb" {
 | subnet\_mapping | A list of subnet mapping blocks describing subnets to attach to network load balancer | `list(map(string))` | `[]` | no |
 | subnets | A list of subnets to associate with the load balancer. e.g. ['subnet-1a2b3c4d','subnet-1a2b3c4e','subnet-1a2b3c4f'] | `list(string)` | n/a | yes |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| target\_groups | A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend\_protocol, backend\_port. Optional key/values are in the target\_groups\_defaults variable. | `any` | `[]` | no |
+| target\_group\_tags | A map of tags to add to all target groups | `map(string)` | `{}` | no |
+| target\_groups | A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend\_protocol, backend\_port | `any` | `[]` | no |
 | vpc\_id | VPC id where the load balancer and other resources will be deployed. | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -110,6 +110,9 @@ module "alb" {
         protocol            = "HTTP"
         matcher             = "200-399"
       }
+      tags = {
+        InstanceTargetGroupTag = "baz"
+      }
     },
     {
       name_prefix                        = "l1-"
@@ -120,5 +123,13 @@ module "alb" {
 
   tags = {
     Project = "Unknown"
+  }
+
+  lb_tags = {
+    MyLoadBalancer = "foo"
+  }
+
+  target_group_tags = {
+    MyGlobalTargetGroupTag = "bar"
   }
 }

--- a/examples/complete-nlb/main.tf
+++ b/examples/complete-nlb/main.tf
@@ -108,6 +108,9 @@ module "nlb" {
       backend_protocol = "TCP_UDP"
       backend_port     = 81
       target_type      = "instance"
+      tags = {
+        tcp_udp = true
+      }
     },
     {
       name_prefix      = "u1-"

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "aws_lb" "this" {
 
   tags = merge(
     var.tags,
+    var.lb_tags,
     {
       Name = var.name != null ? var.name : var.name_prefix
     },
@@ -93,6 +94,8 @@ resource "aws_lb_target_group" "main" {
 
   tags = merge(
     var.tags,
+    var.target_group_tags,
+    lookup(var.target_groups[count.index], "tags", {}),
     {
       "Name" = lookup(var.target_groups[count.index], "name", lookup(var.target_groups[count.index], "name_prefix", ""))
     },

--- a/variables.tf
+++ b/variables.tf
@@ -124,6 +124,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "lb_tags" {
+  description = "A map of tags to add to load balancer"
+  type        = map(string)
+  default     = {}
+}
+
+variable "target_group_tags" {
+  description = "A map of tags to add to all target groups"
+  type        = map(string)
+  default     = {}
+}
+
 variable "security_groups" {
   description = "The security groups to attach to the load balancer. e.g. [\"sg-edcd9784\",\"sg-edcd9785\"]"
   type        = list(string)
@@ -131,7 +143,7 @@ variable "security_groups" {
 }
 
 variable "target_groups" {
-  description = "A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend_protocol, backend_port. Optional key/values are in the target_groups_defaults variable."
+  description = "A list of maps containing key/value pairs that define the target groups to be created. Order of these maps is important and the index of these are to be referenced in listener definitions. Required key/values: name, backend_protocol, backend_port"
   type        = any
   default     = []
 }


### PR DESCRIPTION
## Description

This PR will allow this module to add tags on : 
* load balancer only
* all taget groups
* specific target group

## Motivation and Context

Sometimes, we want to add tags only in a specific resource, and not to all resources. Example, a target group description tag like "use for admin acess". 

## Breaking Changes

Nothing. 

## How Has This Been Tested?

Make a terraform plan on tests

```
terraform plan -out /tmp/plan.out examples/complete-alb
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.aws_route53_zone.this: Refreshing state...
data.aws_vpc.default: Refreshing state...
data.aws_subnet_ids.all: Refreshing state...

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # random_pet.this will be created
  + resource "random_pet" "this" {
      + id        = (known after apply)
      + length    = 2
      + separator = "-"
    }

  # module.acm.aws_acm_certificate.this[0] will be created
  + resource "aws_acm_certificate" "this" {
      + arn                       = (known after apply)
      + domain_name               = "terraform-aws-modules.modules.tf"
      + domain_validation_options = (known after apply)
      + id                        = (known after apply)
      + subject_alternative_names = []
      + validation_emails         = (known after apply)
      + validation_method         = "DNS"
    }

  # module.acm.aws_acm_certificate_validation.this[0] will be created
  + resource "aws_acm_certificate_validation" "this" {
      + certificate_arn         = (known after apply)
      + id                      = (known after apply)
      + validation_record_fqdns = (known after apply)
    }

  # module.acm.aws_route53_record.validation[0] will be created
  + resource "aws_route53_record" "validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z04759191PM0ISO1FPE5A"
    }

  # module.acm.aws_route53_record.validation[1] will be created
  + resource "aws_route53_record" "validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z04759191PM0ISO1FPE5A"
    }

  # module.alb.aws_lb.this[0] will be created
  + resource "aws_lb" "this" {
      + arn                        = (known after apply)
      + arn_suffix                 = (known after apply)
      + dns_name                   = (known after apply)
      + drop_invalid_header_fields = false
      + enable_deletion_protection = false
      + enable_http2               = true
      + id                         = (known after apply)
      + idle_timeout               = 60
      + internal                   = false
      + ip_address_type            = "ipv4"
      + load_balancer_type         = "application"
      + name                       = (known after apply)
      + security_groups            = (known after apply)
      + subnets                    = [
          + "subnet-88059fd2",
          + "subnet-8c3169ea",
          + "subnet-f2ae86ba",
        ]
      + tags                       = (known after apply)
      + vpc_id                     = (known after apply)
      + zone_id                    = (known after apply)

      + subnet_mapping {
          + allocation_id = (known after apply)
          + subnet_id     = (known after apply)
        }

      + timeouts {
          + create = "10m"
          + delete = "10m"
          + update = "10m"
        }
    }

  # module.alb.aws_lb_listener.frontend_http_tcp[0] will be created
  + resource "aws_lb_listener" "frontend_http_tcp" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 80
      + protocol          = "HTTP"
      + ssl_policy        = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.alb.aws_lb_listener.frontend_https[0] will be created
  + resource "aws_lb_listener" "frontend_https" {
      + arn               = (known after apply)
      + certificate_arn   = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 443
      + protocol          = (known after apply)
      + ssl_policy        = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.alb.aws_lb_target_group.main[0] will be created
  + resource "aws_lb_target_group" "main" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + deregistration_delay               = 10
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "h1"
      + port                               = 80
      + protocol                           = "HTTP"
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags                               = {
          + "InstanceTargetGroupTag" = "baz"
          + "MyGlobalTargetGroupTag" = "bar"
          + "Name"                   = "h1"
          + "Project"                = "Unknown"
        }
      + target_type                        = "instance"
      + vpc_id                             = "vpc-cad23db3"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 30
          + matcher             = "200-399"
          + path                = "/healthz"
          + port                = "traffic-port"
          + protocol            = "HTTP"
          + timeout             = 6
          + unhealthy_threshold = 3
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # module.alb.aws_lb_target_group.main[1] will be created
  + resource "aws_lb_target_group" "main" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + deregistration_delay               = 300
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = true
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "l1-"
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags                               = {
          + "MyGlobalTargetGroupTag" = "bar"
          + "Name"                   = "l1-"
          + "Project"                = "Unknown"
        }
      + target_type                        = "lambda"
      + vpc_id                             = "vpc-cad23db3"

      + health_check {
          + enabled             = (known after apply)
          + healthy_threshold   = (known after apply)
          + interval            = (known after apply)
          + matcher             = (known after apply)
          + path                = (known after apply)
          + port                = (known after apply)
          + protocol            = (known after apply)
          + timeout             = (known after apply)
          + unhealthy_threshold = (known after apply)
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # module.security_group.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security group for example usage with ALB"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = (known after apply)
      + vpc_id                 = "vpc-cad23db3"
    }

  # module.security_group.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }

  # module.security_group.aws_security_group_rule.ingress_rules[0] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "HTTP"
      + from_port                = 80
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # module.security_group.aws_security_group_rule.ingress_rules[1] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All IPV4 ICMP"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "icmp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "ingress"
    }

Plan: 14 to add, 0 to change, 0 to destroy.
```

```
terraform plan -out=/tmp/plan.out examples/complete-nlb 
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.aws_route53_zone.this: Refreshing state...
data.aws_vpc.default: Refreshing state...
data.aws_subnet_ids.all: Refreshing state...

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_eip.this[0] will be created
  + resource "aws_eip" "this" {
      + allocation_id     = (known after apply)
      + association_id    = (known after apply)
      + domain            = (known after apply)
      + id                = (known after apply)
      + instance          = (known after apply)
      + network_interface = (known after apply)
      + private_dns       = (known after apply)
      + private_ip        = (known after apply)
      + public_dns        = (known after apply)
      + public_ip         = (known after apply)
      + public_ipv4_pool  = (known after apply)
      + vpc               = true
    }

  # aws_eip.this[1] will be created
  + resource "aws_eip" "this" {
      + allocation_id     = (known after apply)
      + association_id    = (known after apply)
      + domain            = (known after apply)
      + id                = (known after apply)
      + instance          = (known after apply)
      + network_interface = (known after apply)
      + private_dns       = (known after apply)
      + private_ip        = (known after apply)
      + public_dns        = (known after apply)
      + public_ip         = (known after apply)
      + public_ipv4_pool  = (known after apply)
      + vpc               = true
    }

  # aws_eip.this[2] will be created
  + resource "aws_eip" "this" {
      + allocation_id     = (known after apply)
      + association_id    = (known after apply)
      + domain            = (known after apply)
      + id                = (known after apply)
      + instance          = (known after apply)
      + network_interface = (known after apply)
      + private_dns       = (known after apply)
      + private_ip        = (known after apply)
      + public_dns        = (known after apply)
      + public_ip         = (known after apply)
      + public_ipv4_pool  = (known after apply)
      + vpc               = true
    }

  # random_pet.this will be created
  + resource "random_pet" "this" {
      + id        = (known after apply)
      + length    = 2
      + separator = "-"
    }

  # module.acm.aws_acm_certificate.this[0] will be created
  + resource "aws_acm_certificate" "this" {
      + arn                       = (known after apply)
      + domain_name               = "terraform-aws-modules.modules.tf"
      + domain_validation_options = (known after apply)
      + id                        = (known after apply)
      + subject_alternative_names = []
      + validation_emails         = (known after apply)
      + validation_method         = "DNS"
    }

  # module.acm.aws_acm_certificate_validation.this[0] will be created
  + resource "aws_acm_certificate_validation" "this" {
      + certificate_arn         = (known after apply)
      + id                      = (known after apply)
      + validation_record_fqdns = (known after apply)
    }

  # module.acm.aws_route53_record.validation[0] will be created
  + resource "aws_route53_record" "validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z04759191PM0ISO1FPE5A"
    }

  # module.acm.aws_route53_record.validation[1] will be created
  + resource "aws_route53_record" "validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z04759191PM0ISO1FPE5A"
    }

  # module.nlb.aws_lb.this[0] will be created
  + resource "aws_lb" "this" {
      + arn                              = (known after apply)
      + arn_suffix                       = (known after apply)
      + dns_name                         = (known after apply)
      + enable_cross_zone_load_balancing = false
      + enable_deletion_protection       = false
      + id                               = (known after apply)
      + internal                         = false
      + ip_address_type                  = "ipv4"
      + load_balancer_type               = "network"
      + name                             = (known after apply)
      + security_groups                  = (known after apply)
      + subnets                          = (known after apply)
      + tags                             = (known after apply)
      + vpc_id                           = (known after apply)
      + zone_id                          = (known after apply)

      + subnet_mapping {
          + allocation_id = (known after apply)
          + subnet_id     = "subnet-88059fd2"
        }
      + subnet_mapping {
          + allocation_id = (known after apply)
          + subnet_id     = "subnet-8c3169ea"
        }
      + subnet_mapping {
          + allocation_id = (known after apply)
          + subnet_id     = "subnet-f2ae86ba"
        }

      + timeouts {
          + create = "10m"
          + delete = "10m"
          + update = "10m"
        }
    }

  # module.nlb.aws_lb_listener.frontend_http_tcp[0] will be created
  + resource "aws_lb_listener" "frontend_http_tcp" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 81
      + protocol          = "TCP_UDP"
      + ssl_policy        = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.nlb.aws_lb_listener.frontend_http_tcp[1] will be created
  + resource "aws_lb_listener" "frontend_http_tcp" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 82
      + protocol          = "UDP"
      + ssl_policy        = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.nlb.aws_lb_listener.frontend_http_tcp[2] will be created
  + resource "aws_lb_listener" "frontend_http_tcp" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 83
      + protocol          = "TCP"
      + ssl_policy        = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.nlb.aws_lb_listener.frontend_https[0] will be created
  + resource "aws_lb_listener" "frontend_https" {
      + arn               = (known after apply)
      + certificate_arn   = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 84
      + protocol          = (known after apply)
      + ssl_policy        = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.nlb.aws_lb_target_group.main[0] will be created
  + resource "aws_lb_target_group" "main" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + deregistration_delay               = 300
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "tu1-"
      + port                               = 81
      + protocol                           = "TCP_UDP"
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags                               = {
          + "Name"    = "tu1-"
          + "tcp_udp" = "true"
        }
      + target_type                        = "instance"
      + vpc_id                             = "vpc-cad23db3"

      + health_check {
          + enabled             = (known after apply)
          + healthy_threshold   = (known after apply)
          + interval            = (known after apply)
          + matcher             = (known after apply)
          + path                = (known after apply)
          + port                = (known after apply)
          + protocol            = (known after apply)
          + timeout             = (known after apply)
          + unhealthy_threshold = (known after apply)
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # module.nlb.aws_lb_target_group.main[1] will be created
  + resource "aws_lb_target_group" "main" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + deregistration_delay               = 300
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "u1-"
      + port                               = 82
      + protocol                           = "UDP"
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags                               = {
          + "Name" = "u1-"
        }
      + target_type                        = "instance"
      + vpc_id                             = "vpc-cad23db3"

      + health_check {
          + enabled             = (known after apply)
          + healthy_threshold   = (known after apply)
          + interval            = (known after apply)
          + matcher             = (known after apply)
          + path                = (known after apply)
          + port                = (known after apply)
          + protocol            = (known after apply)
          + timeout             = (known after apply)
          + unhealthy_threshold = (known after apply)
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # module.nlb.aws_lb_target_group.main[2] will be created
  + resource "aws_lb_target_group" "main" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + deregistration_delay               = 10
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "t1-"
      + port                               = 83
      + protocol                           = "TCP"
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags                               = {
          + "Name" = "t1-"
        }
      + target_type                        = "ip"
      + vpc_id                             = "vpc-cad23db3"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 30
          + matcher             = (known after apply)
          + path                = "/healthz"
          + port                = "traffic-port"
          + protocol            = "HTTP"
          + timeout             = 6
          + unhealthy_threshold = 3
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # module.nlb.aws_lb_target_group.main[3] will be created
  + resource "aws_lb_target_group" "main" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + deregistration_delay               = 300
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "t2-"
      + port                               = 84
      + protocol                           = "TLS"
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags                               = {
          + "Name" = "t2-"
        }
      + target_type                        = "instance"
      + vpc_id                             = "vpc-cad23db3"

      + health_check {
          + enabled             = (known after apply)
          + healthy_threshold   = (known after apply)
          + interval            = (known after apply)
          + matcher             = (known after apply)
          + path                = (known after apply)
          + port                = (known after apply)
          + protocol            = (known after apply)
          + timeout             = (known after apply)
          + unhealthy_threshold = (known after apply)
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

Plan: 17 to add, 0 to change, 0 to destroy.
```

```
terraform plan -out /tmp/plan.out examples/disabled 
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```