### PR TITLE
feat: Added listener rules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ These types of resources are supported:
 * [Load Balancer Listener](https://www.terraform.io/docs/providers/aws/r/lb_listener.html)
 * [Load Balancer Listener Certificate](https://www.terraform.io/docs/providers/aws/r/lb_listener_certificate.html)
 * [Load Balancer Listener default actions](https://www.terraform.io/docs/providers/aws/r/lb_listener.html) - All actions supported.
+* [Load Balancer Listener Rule](https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html)
 * [Target Group](https://www.terraform.io/docs/providers/aws/r/lb_target_group.html)
 
 Not supported (yet):
 
-* [Load Balancer Listener Rule](https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html)
 * [Target Group Attachment](https://www.terraform.io/docs/providers/aws/r/lb_target_group_attachment.html)
 
 ## Terraform versions
@@ -137,6 +137,87 @@ module "alb" {
   }
 }
 ```
+
+Cognito Authentication only on certain routes, with redirects for other routes:
+
+```hcl
+module "alb" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+  
+  name = "my-alb"
+
+  load_balancer_type = "application"
+
+  vpc_id             = "vpc-abcde012"
+  subnets            = ["subnet-abcde012", "subnet-bcde012a"]
+  security_groups    = ["sg-edcd9784", "sg-edcd9785"]
+  
+  access_logs = {
+    bucket = "my-alb-logs"
+  }
+
+  target_groups = [
+    {
+      name_prefix      = "default"
+      backend_protocol = "HTTPS"
+      backend_port     = 443
+      target_type      = "instance"
+    }
+  ]
+
+  https_listeners = [
+    {
+      port                 = 443
+      certificate_arn      = "arn:aws:iam::123456789012:server-certificate/test_cert-123456789012"
+    }
+  ]
+
+  https_listener_rules = [
+    {
+      https_listener_index = 0
+      priority             = 5000
+
+      actions = [{
+        type        = "redirect"
+        status_code = "HTTP_302"
+        host        = "www.youtube.com"
+        path        = "/watch"
+        query       = "v=dQw4w9WgXcQ"
+        protocol    = "HTTPS"
+      }]
+
+      conditions = [{
+        path_patterns = ["/onboarding", "/docs"]
+      }]
+    },
+    {
+      https_listener_index = 0
+      priority             = 2
+
+      actions = [
+        {
+          type = "authenticate-cognito"
+
+          user_pool_arn       = "arn:aws:cognito-idp::123456789012:userpool/test-pool"
+          user_pool_client_id = "6oRmFiS0JHk="
+          user_pool_domain    = "test-domain-com"
+        },
+        {
+          type               = "forward"
+          target_group_index = 0
+        }
+      ]
+
+      conditions = [{
+        path_patterns = ["/protected-route", "private/*"]
+      }]
+    }
+  ]
+}
+```
+
+When you're using ALB Listener rules, make sure that every rule's `actions` block ends in a `forward`, `redirect`, or `fixed-response` action so that every rule will resolve to some sort of an HTTP response. Checkout the [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-update-rules.html) for more information.
 
 ### Network Load Balancer (TCP_UDP, UDP, TCP and TLS listeners)
 

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -202,7 +202,7 @@ module "alb" {
     },
     {
       https_listener_index = 1
-      priority = 2
+      priority             = 2
 
       actions = [
         {
@@ -226,23 +226,23 @@ module "alb" {
       ]
 
       conditions = [{
-        host_headers = ["X-Make-Me-Authenticate", "X-I-Like-Auth"]
+        host_headers = ["foobar.com"]
       }]
     },
     {
       https_listener_index = 0
       priority             = 3
       actions = [{
-        type        = "fixed-response"
+        type         = "fixed-response"
         content_type = "text/plain"
-        status_code = 200
+        status_code  = 200
         message_body = "This is a fixed response"
       }]
 
       conditions = [{
         http_headers = [{
-          http_header_name   = "x-Gimme-Fixed-Response"
-          values = ["yes", "please", "right now"]
+          http_header_name = "x-Gimme-Fixed-Response"
+          values           = ["yes", "please", "right now"]
         }]
       }]
     },

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,213 @@ resource "aws_lb_target_group" "main" {
   }
 }
 
+resource "aws_lb_listener_rule" "https_listener_rule" {
+  count = var.create_lb ? length(var.https_listener_rules) : 0
+
+  listener_arn = aws_lb_listener.frontend_https[lookup(var.https_listener_rules[count.index], "https_listener_index", count.index)].arn
+  priority     = lookup(var.https_listener_rules[count.index], "priority", null)
+
+  # authenticate-cognito actions
+  dynamic "action" {
+    for_each = [
+      for action_rule in var.https_listener_rules[count.index].actions :
+      action_rule
+      if action_rule.type == "authenticate-cognito"
+    ]
+
+    content {
+      type = action.value["type"]
+      authenticate_cognito {
+        authentication_request_extra_params = lookup(action.value, "authentication_request_extra_params", null)
+        on_unauthenticated_request          = lookup(action.value, "on_authenticated_request", null)
+        scope                               = lookup(action.value, "scope", null)
+        session_cookie_name                 = lookup(action.value, "session_cookie_name", null)
+        session_timeout                     = lookup(action.value, "session_timeout", null)
+        user_pool_arn                       = action.value["user_pool_arn"]
+        user_pool_client_id                 = action.value["user_pool_client_id"]
+        user_pool_domain                    = action.value["user_pool_domain"]
+      }
+    }
+  }
+
+  # authenticate-oidc actions
+  dynamic "action" {
+    for_each = [
+      for action_rule in var.https_listener_rules[count.index].actions :
+      action_rule
+      if action_rule.type == "authenticate-oidc"
+    ]
+
+    content {
+      type = action.value["type"]
+      authenticate_oidc {
+        # Max 10 extra params
+        authentication_request_extra_params = lookup(action.value, "authentication_request_extra_params", null)
+        authorization_endpoint              = action.value["authorization_endpoint"]
+        client_id                           = action.value["client_id"]
+        client_secret                       = action.value["client_secret"]
+        issuer                              = action.value["issuer"]
+        on_unauthenticated_request          = lookup(action.value, "on_unauthenticated_request", null)
+        scope                               = lookup(action.value, "scope", null)
+        session_cookie_name                 = lookup(action.value, "session_cookie_name", null)
+        session_timeout                     = lookup(action.value, "session_timeout", null)
+        token_endpoint                      = action.value["token_endpoint"]
+        user_info_endpoint                  = action_rule.value["user_info_endpoint"]
+      }
+    }
+  }
+
+  # redirect actions
+  dynamic "action" {
+    for_each = [
+      for action_rule in var.https_listener_rules[count.index].actions :
+      action_rule
+      if action_rule.type == "redirect"
+    ]
+
+    content {
+      type = action.value["type"]
+      redirect {
+        host        = lookup(action.value, "host", null)
+        path        = lookup(action.value, "path", null)
+        port        = lookup(action.value, "port", null)
+        protocol    = lookup(action.value, "protocol", null)
+        query       = lookup(action.value, "query", null)
+        status_code = action.value["status_code"]
+      }
+    }
+  }
+
+  # fixed-response actions
+  dynamic "action" {
+    for_each = [
+      for action_rule in var.https_listener_rules[count.index].actions :
+      action_rule
+      if action_rule.type == "fixed-response"
+    ]
+
+    content {
+      type = action.value["type"]
+      fixed_response {
+        message_body = lookup(action.value, "message_body", null)
+        status_code  = lookup(action.value, "status_code", null)
+        content_type = action.value["content_type"]
+      }
+    }
+  }
+
+  # forward actions
+  dynamic "action" {
+    for_each = [
+      for action_rule in var.https_listener_rules[count.index].actions :
+      action_rule
+      if action_rule.type == "forward"
+    ]
+
+    content {
+      type             = action.value["type"]
+      target_group_arn = aws_lb_target_group.main[lookup(action.value, "target_group_index", count.index)].id
+    }
+  }
+
+  # Path Pattern condition
+  dynamic "condition" {
+    for_each = [
+      for condition_rule in var.https_listener_rules[count.index].conditions :
+      condition_rule
+      if length(lookup(condition_rule, "path_patterns", [])) > 0
+    ]
+
+    content {
+      path_pattern {
+        values = condition.value["path_patterns"]
+      }
+    }
+  }
+
+  # Host header condition
+  dynamic "condition" {
+    for_each = [
+      for condition_rule in var.https_listener_rules[count.index].conditions :
+      condition_rule
+      if length(lookup(condition_rule, "host_headers", [])) > 0
+    ]
+
+    content {
+      host_header {
+        values = condition.value["host_headers"]
+      }
+    }
+  }
+
+  # Http header condition
+  dynamic "condition" {
+    for_each = [
+      for condition_rule in var.https_listener_rules[count.index].conditions :
+      condition_rule
+      if length(lookup(condition_rule, "http_headers", [])) > 0
+    ]
+
+    content {
+      http_header {
+        http_header_name = condition.value["http_headers"]["http_header_name"]
+        values           = condition.value["http_headers"]["values"]
+      }
+    }
+  }
+
+  # Http request method condition
+  dynamic "condition" {
+    for_each = [
+      for condition_rule in var.https_listener_rules[count.index].conditions :
+      condition_rule
+      if length(lookup(condition_rule, "http_request_methods", [])) > 0
+    ]
+
+    content {
+      http_request_method {
+        values = condition.value["http_request_methods"]
+      }
+    }
+  }
+
+  # Query string condition
+  dynamic "condition" {
+    for_each = [
+      for condition_rule in var.https_listener_rules[count.index].conditions :
+      condition_rule
+      if length(lookup(condition_rule, "query_strings", [])) > 0
+    ]
+
+    content {
+      dynamic "query_string" {
+        for_each = condition.value["query_strings"]
+
+        content {
+          key   = lookup(query_string.value, "key", null)
+          value = query_string.value["value"]
+        }
+      }
+    }
+  }
+
+  # Source IP address condition
+  dynamic "condition" {
+    for_each = [
+      for condition_rule in var.https_listener_rules[count.index].conditions :
+      condition_rule
+      if length(lookup(condition_rule, "source_ips", [])) > 0
+    ]
+
+    content {
+      source_ip {
+        values = condition.value["source_ips"]
+      }
+    }
+  }
+}
+
+
 resource "aws_lb_listener" "frontend_http_tcp" {
   count = var.create_lb ? length(var.http_tcp_listeners) : 0
 

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
         session_cookie_name                 = lookup(action.value, "session_cookie_name", null)
         session_timeout                     = lookup(action.value, "session_timeout", null)
         token_endpoint                      = action.value["token_endpoint"]
-        user_info_endpoint                  = action_rule.value["user_info_endpoint"]
+        user_info_endpoint                  = action.value["user_info_endpoint"]
       }
     }
   }
@@ -258,9 +258,13 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
     ]
 
     content {
-      http_header {
-        http_header_name = condition.value["http_headers"]["http_header_name"]
-        values           = condition.value["http_headers"]["values"]
+      dynamic "http_header" {
+        for_each = condition.value["http_headers"]
+
+        content {
+          http_header_name = http_header.value["http_header_name"]
+          values           = http_header.value["values"]
+        }
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,12 @@ variable "http_tcp_listeners" {
   default     = []
 }
 
+variable "https_listener_rules" {
+  description = "A list of maps describing the Listener Rules for this ALB. Required key/values: actions, conditions. Optional key/values: priority, https_listener_index (default to https_listeners[count.index])"
+  type        = any
+  default     = []
+}
+
 variable "idle_timeout" {
   description = "The time in seconds that the connection is allowed to be idle."
   type        = number


### PR DESCRIPTION
## Description
Added listener rules support.

This PR adds support for creating `aws_lb_listener_rule` resources, with all currently supported actions and conditions from the terraform provider supported. For now, I only added support to https listeners, but adding http listener support later would be trivial.

Docs wise, I updated the REAMDE to include an example of using the listener_rule var, and also updated the example to have near-complete usage.

## Motivation and Context
This repo recently added support for updating the default rule for a listener, which was awesome. This PR goes one step further, for adding rules with conditions, such as only protecting certain paths with authentication.

Fixes: https://github.com/terraform-aws-modules/terraform-aws-alb/issues/154

## Breaking Changes
There are no breaking changes. Plans will be empty on upgrades to use this branch's code if users do not make any changes.

## How Has This Been Tested?
I have tested some of the actions/conditions in the `dev` environment in my companies codebase. I also updated the complete alb example to use almost every actions/condition type and ensured that `terraform validate` came up clean.
