### PR TITLE
feat: Support Least Outstanding Requests algorithm for load balancing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v5.4.0"></a>
+## [v5.4.0] - 2020-04-13
+
+- feat: Add more specific tags ([#151](https://github.com/terraform-aws-modules/terraform-aws-alb/issues/151))
+
+
 <a name="v5.3.0"></a>
 ## [v5.3.0] - 2020-04-04
 
@@ -220,7 +226,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-alb/compare/v5.3.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-alb/compare/v5.4.0...HEAD
+[v5.4.0]: https://github.com/terraform-aws-modules/terraform-aws-alb/compare/v5.3.0...v5.4.0
 [v5.3.0]: https://github.com/terraform-aws-modules/terraform-aws-alb/compare/v5.2.0...v5.3.0
 [v5.2.0]: https://github.com/terraform-aws-modules/terraform-aws-alb/compare/v5.1.0...v5.2.0
 [v5.1.0]: https://github.com/terraform-aws-modules/terraform-aws-alb/compare/v5.0.0...v5.1.0


### PR DESCRIPTION
## Description
Add optional arguments to target group:  `load_balancing_algorithm_type`

https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#load_balancing_algorithm_type

## Motivation and Context
Closes #157 

## Breaking Changes
No breaking changes

## How Has This Been Tested?
Created Load balancer with `load_balancing_algorithm_type` set to `least_outstanding_requests`, `round_robin`, and unset. All load balancers' target group created as it should be.
