### PR TITLE
feat: Support AWS provider 3.0 and Terraform 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Not supported (yet):
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v5.0`. Submit pull-requests to `master` branch.
+Terraform 0.12 and newer. Pin module version to `~> v5.0`. Submit pull-requests to `master` branch.
 
 Terraform 0.11. Pin module version to `~> v3.0`. Submit pull-requests to `terraform011` branch.
 
@@ -220,14 +220,14 @@ module "lb" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
-| aws | >= 2.54 |
+| terraform | >= 0.12.6, < 0.14 |
+| aws | >= 2.54, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.54 |
+| aws | >= 2.54, < 4.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ module "lb" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12 |
-| aws | ~> 2.54 |
+| aws | >= 2.54 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.54 |
+| aws | >= 2.54 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = ">= 2.54"
+    aws = ">= 2.54, < 4.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12"
 
   required_providers {
-    aws = "~> 2.54"
+    aws = ">= 2.54"
   }
 }


### PR DESCRIPTION
Fixes #165

## Description
Support AWS provider 3.0 by allowing any version greater than 2.54

## Motivation and Context
Per Terraform documentation, pessimistic version constraints should not be used for providers
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions

## Breaking Changes
See AWS provider [documentation](https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v3.0.0)

## How Has This Been Tested?
None yet.
