### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -310,6 +310,20 @@ module "lb" {
 |------|---------|
 | aws | >= 2.54 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_lb](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb) |
+| [aws_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_listener) |
+| [aws_lb_listener_certificate](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_listener_certificate) |
+| [aws_lb_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_listener_rule) |
+| [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_target_group) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -359,7 +373,6 @@ module "lb" {
 | this\_lb\_dns\_name | The DNS name of the load balancer. |
 | this\_lb\_id | The ID and ARN of the load balancer we created. |
 | this\_lb\_zone\_id | The zone\_id of the load balancer to assist with creating DNS records. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -318,11 +318,11 @@ No Modules.
 
 | Name |
 |------|
-| [aws_lb](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb) |
-| [aws_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_listener) |
 | [aws_lb_listener_certificate](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_listener_certificate) |
 | [aws_lb_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_listener_rule) |
+| [aws_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_listener) |
 | [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb_target_group) |
+| [aws_lb](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/lb) |
 
 ## Inputs
 

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -30,6 +30,27 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 2.54 |
 | random | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| acm | terraform-aws-modules/acm/aws | ~> 2.0 |
+| alb | ../../ |  |
+| lb_disabled | ../../ |  |
+| security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cognito_user_pool](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/cognito_user_pool) |
+| [aws_cognito_user_pool_client](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/cognito_user_pool_client) |
+| [aws_cognito_user_pool_domain](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/cognito_user_pool_domain) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/route53_zone) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/vpc) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -50,5 +71,4 @@ No input.
 | this\_lb\_dns\_name | The DNS name of the load balancer. |
 | this\_lb\_id | The ID and ARN of the load balancer we created. |
 | this\_lb\_zone\_id | The zone\_id of the load balancer to assist with creating DNS records. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -43,9 +43,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_cognito_user_pool](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/cognito_user_pool) |
 | [aws_cognito_user_pool_client](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/cognito_user_pool_client) |
 | [aws_cognito_user_pool_domain](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/cognito_user_pool_domain) |
+| [aws_cognito_user_pool](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/cognito_user_pool) |
 | [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/route53_zone) |
 | [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/subnet_ids) |
 | [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/vpc) |

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -30,6 +30,23 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 2.54 |
 | random | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| acm | terraform-aws-modules/acm/aws | ~> 2.0 |
+| nlb | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/resources/eip) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/route53_zone) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.54/docs/data-sources/vpc) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -50,5 +67,4 @@ No input.
 | this\_lb\_dns\_name | The DNS name of the load balancer. |
 | this\_lb\_id | The ID and ARN of the load balancer we created. |
 | this\_lb\_zone\_id | The zone\_id of the load balancer to assist with creating DNS records. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
