### PR TITLE
feat: support for target group protocol_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,13 +309,13 @@ module "lb" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.54 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
 
 ## Modules
 

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.54 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -285,6 +285,7 @@ module "alb" {
         protocol            = "HTTP"
         matcher             = "200-399"
       }
+      protocol_version = "HTTP1"
       tags = {
         InstanceTargetGroupTag = "baz"
       }

--- a/examples/complete-alb/versions.tf
+++ b/examples/complete-alb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 2.54"
+    aws    = ">= 3.27"
     random = ">= 2.0"
     null   = ">= 2.0"
   }

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.54 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/complete-nlb/versions.tf
+++ b/examples/complete-nlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 2.54"
+    aws    = ">= 3.27"
     random = ">= 2.0"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -57,10 +57,11 @@ resource "aws_lb_target_group" "main" {
   name        = lookup(var.target_groups[count.index], "name", null)
   name_prefix = lookup(var.target_groups[count.index], "name_prefix", null)
 
-  vpc_id      = var.vpc_id
-  port        = lookup(var.target_groups[count.index], "backend_port", null)
-  protocol    = lookup(var.target_groups[count.index], "backend_protocol", null) != null ? upper(lookup(var.target_groups[count.index], "backend_protocol")) : null
-  target_type = lookup(var.target_groups[count.index], "target_type", null)
+  vpc_id           = var.vpc_id
+  port             = lookup(var.target_groups[count.index], "backend_port", null)
+  protocol         = lookup(var.target_groups[count.index], "backend_protocol", null) != null ? upper(lookup(var.target_groups[count.index], "backend_protocol")) : null
+  protocol_version = lookup(var.target_groups[count.index], "protocol_version", null) != null ? upper(lookup(var.target_groups[count.index], "protocol_version")) : null
+  target_type      = lookup(var.target_groups[count.index], "target_type", null)
 
   deregistration_delay               = lookup(var.target_groups[count.index], "deregistration_delay", null)
   slow_start                         = lookup(var.target_groups[count.index], "slow_start", null)

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 2.54"
+    aws = ">= 3.27"
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This pull request adds support for the [`protocol_version`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#protocol_version) argument of the `aws_lb_target_group` resource.

Resolves #179

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

hashicorp/terraform-provider-aws#17534

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

N/A

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
