### PR TITLE
chore: Update readme note on S3 access logs bucket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ It's recommended you use this module with [terraform-aws-vpc](https://registry.t
 
 ## Notes
 
-1. Terraform AWS provider v2.39.0 (via Terraform 0.12) has [issue #7987](https://github.com/terraform-providers/terraform-provider-aws/issues/7987) related to "Provider produced inconsistent final plan". It means that S3 bucket has to be created before referencing it as an argument inside `access_logs = { bucket = "my-already-created-bucket-for-logs" }`, so this won't work: `access_logs = { bucket = module.log_bucket.this_s3_bucket_id }`.
+1. Terraform AWS provider >= v2.39.0 (via Terraform >= 0.12) has [issue #16674](https://github.com/hashicorp/terraform-provider-aws/issues/16674) related to "Provider produced inconsistent final plan". It means that S3 bucket has to be created before referencing it as an argument inside `access_logs = { bucket = "my-already-created-bucket-for-logs" }`, so this won't work: `access_logs = { bucket = module.log_bucket.this_s3_bucket_id }`.
 
 ## Conditional creation
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Update the readme with new github issue and terraform/aws provider versions that contain the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous link was closed, suggesting it was fixed, however the problem still persists in the newest versions of terraform (v0.14.8) and the aws provider (v3.33.0).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None 

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Can confirm that this is still an issue by uncommenting the commented out `log_bucket` module and `access_logs` in the alb example.