### PR TITLE
feat: Add target group attachment capabilities

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.[0-9]+-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.[0-9]+-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12\..+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Zip archive
+*.zip

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ These types of resources are supported:
 * [Load Balancer Listener default actions](https://www.terraform.io/docs/providers/aws/r/lb_listener.html) - All actions supported.
 * [Load Balancer Listener Rule](https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html)
 * [Target Group](https://www.terraform.io/docs/providers/aws/r/lb_target_group.html)
-
-Not supported (yet):
-
 * [Target Group Attachment](https://www.terraform.io/docs/providers/aws/r/lb_target_group_attachment.html)
 
 ## Terraform versions
@@ -31,7 +28,7 @@ HTTP and HTTPS listeners with default actions:
 module "alb" {
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 5.0"
-  
+
   name = "my-alb"
 
   load_balancer_type = "application"
@@ -39,7 +36,7 @@ module "alb" {
   vpc_id             = "vpc-abcde012"
   subnets            = ["subnet-abcde012", "subnet-bcde012a"]
   security_groups    = ["sg-edcd9784", "sg-edcd9785"]
-  
+
   access_logs = {
     bucket = "my-alb-logs"
   }
@@ -50,6 +47,16 @@ module "alb" {
       backend_protocol = "HTTP"
       backend_port     = 80
       target_type      = "instance"
+      targets = [
+        {
+          target_id = "i-0123456789abcdefg"
+          port = 80
+        },
+        {
+          target_id = "i-a1b2c3d4e5f6g7h8i"
+          port = 8080
+        }
+      ]
     }
   ]
 
@@ -82,7 +89,7 @@ HTTP to HTTPS redirect and HTTPS cognito authentication:
 module "alb" {
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 5.0"
-  
+
   name = "my-alb"
 
   load_balancer_type = "application"
@@ -90,7 +97,7 @@ module "alb" {
   vpc_id             = "vpc-abcde012"
   subnets            = ["subnet-abcde012", "subnet-bcde012a"]
   security_groups    = ["sg-edcd9784", "sg-edcd9785"]
-  
+
   access_logs = {
     bucket = "my-alb-logs"
   }
@@ -144,7 +151,7 @@ Cognito Authentication only on certain routes, with redirects for other routes:
 module "alb" {
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 5.0"
-  
+
   name = "my-alb"
 
   load_balancer_type = "application"
@@ -152,7 +159,7 @@ module "alb" {
   vpc_id             = "vpc-abcde012"
   subnets            = ["subnet-abcde012", "subnet-bcde012a"]
   security_groups    = ["sg-edcd9784", "sg-edcd9785"]
-  
+
   access_logs = {
     bucket = "my-alb-logs"
   }
@@ -225,14 +232,14 @@ When you're using ALB Listener rules, make sure that every rule's `actions` bloc
 module "nlb" {
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 5.0"
-  
+
   name = "my-nlb"
 
   load_balancer_type = "network"
 
   vpc_id  = "vpc-abcde012"
   subnets = ["subnet-abcde012", "subnet-bcde012a"]
-  
+
   access_logs = {
     bucket = "my-nlb-logs"
   }
@@ -323,6 +330,7 @@ No Modules.
 | [aws_lb_listener_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) |
 | [aws_lb_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) |
 | [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) |
+| [aws_lb_target_group_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) |
 
 ## Inputs
 
@@ -367,6 +375,7 @@ No Modules.
 | https\_listener\_ids | The IDs of the load balancer listeners created. |
 | target\_group\_arn\_suffixes | ARN suffixes of our target groups - can be used with CloudWatch. |
 | target\_group\_arns | ARNs of the target groups. Useful for passing to your Auto Scaling group. |
+| target\_group\_attachments | ARNs of the target group attachment IDs. |
 | target\_group\_names | Name of the target group. Useful for passing to your CodeDeploy Deployment Group. |
 | this\_lb\_arn | The ID and ARN of the load balancer we created. |
 | this\_lb\_arn\_suffix | ARN suffix of our load balancer - can be used with CloudWatch. |

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ No modules.
 | [aws_lb_listener_certificate.https_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
 | [aws_lb_listener_rule.https_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group_attachment.tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
+| [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ module "lb" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
 
 ## Providers

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -21,6 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
@@ -28,6 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.54 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
@@ -36,6 +38,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 2.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 1.0 |
 | <a name="module_lb_disabled"></a> [lb\_disabled](#module\_lb\_disabled) | ../../ |  |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
 
@@ -46,7 +49,10 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_cognito_user_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
 | [aws_cognito_user_pool_client.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client) | resource |
 | [aws_cognito_user_pool_domain.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_domain) | resource |
+| [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -65,6 +65,7 @@ No input.
 | https\_listener\_ids | The IDs of the load balancer listeners created. |
 | target\_group\_arn\_suffixes | ARN suffixes of our target groups - can be used with CloudWatch. |
 | target\_group\_arns | ARNs of the target groups. Useful for passing to your Auto Scaling group. |
+| target\_group\_attachments | ARNs of the target group attachment IDs. |
 | target\_group\_names | Name of the target group. Useful for passing to your CodeDeploy Deployment Group. |
 | this\_lb\_arn | The ID and ARN of the load balancer we created. |
 | this\_lb\_arn\_suffix | ARN suffix of our load balancer - can be used with CloudWatch. |

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -408,5 +408,5 @@ module "lambda_function" {
     }
   }
 
-  depends_on = [null_resource.download_package]
+  #  depends_on = [null_resource.download_package]
 }

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -285,6 +285,16 @@ module "alb" {
         protocol            = "HTTP"
         matcher             = "200-399"
       }
+      targets = [
+        {
+          target_id = "i-0123456789abcdefg"
+          port = 80
+        },
+        {
+          target_id = "i-a1b2c3d4e5f6g7h8i"
+          port = 8080
+        }
+      ]
       tags = {
         InstanceTargetGroupTag = "baz"
       }
@@ -293,6 +303,14 @@ module "alb" {
       name_prefix                        = "l1-"
       target_type                        = "lambda"
       lambda_multi_value_headers_enabled = true
+      targets = [
+        {
+          target_id = "arn:aws:lambda:us-east-1:123456789012:function:lambda_function_1"
+        },
+        {
+          target_id = "arn:aws:lambda:us-east-1:123456789012:function:lambda_function_2"
+        }
+      ]
     },
   ]
 

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -408,5 +408,5 @@ module "lambda_function" {
     }
   }
 
-  #  depends_on = [null_resource.download_package]
+  depends_on = [null_resource.download_package]
 }

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -288,11 +288,11 @@ module "alb" {
       targets = [
         {
           target_id = "i-0123456789abcdefg"
-          port = 80
+          port      = 80
         },
         {
           target_id = "i-a1b2c3d4e5f6g7h8i"
-          port = 8080
+          port      = 8080
         }
       ]
       tags = {

--- a/examples/complete-alb/outputs.tf
+++ b/examples/complete-alb/outputs.tf
@@ -57,3 +57,8 @@ output "target_group_names" {
   description = "Name of the target group. Useful for passing to your CodeDeploy Deployment Group."
   value       = module.alb.target_group_names
 }
+
+output "target_group_attachments" {
+  description = "ARNs of the target group attachment IDs."
+  value       = module.alb.target_group_attachments
+}

--- a/examples/complete-alb/versions.tf
+++ b/examples/complete-alb/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 2.54"

--- a/examples/complete-alb/versions.tf
+++ b/examples/complete-alb/versions.tf
@@ -4,5 +4,6 @@ terraform {
   required_providers {
     aws    = ">= 2.54"
     random = ">= 2.0"
+    null   = ">= 2.0"
   }
 }

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/complete-nlb/versions.tf
+++ b/examples/complete-nlb/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 2.54"

--- a/main.tf
+++ b/main.tf
@@ -346,7 +346,6 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
   }
 }
 
-
 resource "aws_lb_listener" "frontend_http_tcp" {
   count = var.create_lb ? length(var.http_tcp_listeners) : 0
 

--- a/main.tf
+++ b/main.tf
@@ -118,12 +118,12 @@ locals {
   # can be added later and only need to be updated in the attachment resource below.
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment#argument-reference
   target_group_attachments = flatten([
-      for key, groups in var.target_groups : [
-        for k, targets in groups : [
-          for idx, target in targets : merge({tg_index = key}, target)
-        ]
-        if k == "targets"
+    for key, groups in var.target_groups : [
+      for k, targets in groups : [
+        for idx, target in targets : merge({ tg_index = key }, target)
       ]
+      if k == "targets"
+    ]
   ])
 }
 

--- a/main.tf
+++ b/main.tf
@@ -117,23 +117,21 @@ locals {
   # the function argument reference. This means any additional arguments
   # can be added later and only need to be updated in the attachment resource below.
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment#argument-reference
-  target_group_attachments = flatten([
-    for key, groups in var.target_groups : [
-      for k, targets in groups : [
-        for idx, target in targets : merge({ tg_index = key }, target)
-      ]
+  target_group_attachments = merge(flatten([
+    for index, group in var.target_groups : [
+      for k, targets in group : {
+        for target_key, target in targets : join(".", [index, target_key]) => merge({ tg_index = index }, target)
+      }
       if k == "targets"
     ]
-  ])
+  ])...)
 }
 
-resource "aws_lb_target_group_attachment" "tg" {
-  for_each = {
-    for attachment in local.target_group_attachments : "${attachment.tg_index}.${attachment.target_id}" => attachment
-  }
+resource "aws_lb_target_group_attachment" "this" {
+  for_each = local.target_group_attachments
 
   target_group_arn  = aws_lb_target_group.main[each.value.tg_index].arn
-  target_id         = lookup(each.value, "target_id")
+  target_id         = each.value.target_id
   port              = lookup(each.value, "port", null)
   availability_zone = lookup(each.value, "availability_zone", null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,7 +60,7 @@ output "target_group_names" {
 
 output "target_group_attachments" {
   description = "ARNs of the target group attachment IDs."
-  value       = [
+  value = [
     for tg in aws_lb_target_group_attachment.tg : tg.id
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,7 +60,7 @@ output "target_group_names" {
 
 output "target_group_attachments" {
   description = "ARNs of the target group attachment IDs."
-  value = [
-    for tg in aws_lb_target_group_attachment.tg : tg.id
-  ]
+  value = {
+    for k, v in aws_lb_target_group_attachment.this : k => v.id
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -57,3 +57,10 @@ output "target_group_names" {
   description = "Name of the target group. Useful for passing to your CodeDeploy Deployment Group."
   value       = aws_lb_target_group.main.*.name
 }
+
+output "target_group_attachments" {
+  description = "ARNs of the target group attachment IDs."
+  value       = [
+    for tg in aws_lb_target_group_attachment.tg : tg.id
+  ]
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 2.54"


### PR DESCRIPTION
## Description
Allows for the creation of a "targets" index inside the target_groups variable, where the parameters of the attachment can be defined. The same arguments that are used for the target_group_attachment resource, are the same arguments that should/can be defined. Any additional arguments are created during the "product mapping", but are not used in the resource, but allows for easy upgrading in the future if more arguments are added (only have to update on the resource function)

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment#argument-reference

## Motivation and Context
Allow attaching EC2 instance(s) and Lambda functions to the target groups created by this module so all resources can be managed in one location.  Currently, there's no functionality to add any attachments to the target groups this module creates and everything needs to be additionally defined/coded

* https://github.com/terraform-aws-modules/terraform-aws-alb/issues/134
* https://github.com/terraform-aws-modules/terraform-aws-alb/issues/189

## Breaking Changes
This should be backwards compatible, if no "targets" are defined on the target_group variable, no attachments are created.

## How Has This Been Tested?
[x] I have tested and validated these changes using one or more of the provided examples/* projects

This was manually tested in a sandbox AWS environment on actual ALB/EC2 resources. I currently don't work w/ lambda function attached to any type of LB, so I did not test that. But since the function calls are the same on the target_group_attachment resource between an EC2 instance and a Lambda Function and this is just a mapping of parameters to that function, I really don't anticipate any issues.  

variable definition can look like this now
```
    target_groups = [
        {
            name = "tg-with-targets"
            backend_protocol = "HTTP"
            backend_port = "80"
            target_type = "instance"
            deregistration_delay = 300
            health_check = { ... }
            stickiness = { ... }
            targets = [
                {
                    target_id = "i-0123456789abcdefg"
                    port = 80
                },
               {
                    target_id = "i-a1b2c3d4e5f6g7h8i"
                    port = 8080
                }
            ]
        },
        {
            name = "tg-without-targets"
            backend_protocol = "HTTP"
            backend_port = "80"
            target_type = "instance"
            deregistration_delay = 300
            health_check = { ... }
            stickiness = { ... }
        }
    ]
```
