### PR TITLE
feat: Adding support for ALPN policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
-
 <a name="v6.1.0"></a>
 ## [v6.1.0] - 2021-05-15
 
 - feat: Add tags to listener and listener rules ([#199](https://github.com/terraform-aws-modules/terraform-aws-alb/issues/199))
+- feat: Added support to map ALPN policies in target group attachments.
 - chore: update CI/CD to use stable `terraform-docs` release artifact and discoverable Apache2.0 license ([#198](https://github.com/terraform-aws-modules/terraform-aws-alb/issues/198))
 - chore: Updated versions in README
 - chore: Updated versions in README

--- a/main.tf
+++ b/main.tf
@@ -412,7 +412,7 @@ resource "aws_lb_listener" "frontend_https" {
   protocol        = lookup(var.https_listeners[count.index], "protocol", "HTTPS")
   certificate_arn = var.https_listeners[count.index]["certificate_arn"]
   ssl_policy      = lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)
-  alpn_policy     = try(var.encrypted_listeners[count.index]["alpn_policy"], null)
+  alpn_policy     = try(var.https_listeners[count.index]["alpn_policy"], null)
 
   dynamic "default_action" {
     for_each = length(keys(var.https_listeners[count.index])) == 0 ? [] : [var.https_listeners[count.index]]

--- a/main.tf
+++ b/main.tf
@@ -412,7 +412,7 @@ resource "aws_lb_listener" "frontend_https" {
   protocol        = lookup(var.https_listeners[count.index], "protocol", "HTTPS")
   certificate_arn = var.https_listeners[count.index]["certificate_arn"]
   ssl_policy      = lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)
-  alpn_policy     = try(var.https_listeners[count.index]["alpn_policy"], null)
+  alpn_policy     = lookup(var.https_listeners[count.index], "alpn_policy", null)
 
   dynamic "default_action" {
     for_each = length(keys(var.https_listeners[count.index])) == 0 ? [] : [var.https_listeners[count.index]]

--- a/main.tf
+++ b/main.tf
@@ -412,7 +412,7 @@ resource "aws_lb_listener" "frontend_https" {
   protocol        = lookup(var.https_listeners[count.index], "protocol", "HTTPS")
   certificate_arn = var.https_listeners[count.index]["certificate_arn"]
   ssl_policy      = lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)
-  alpn_policy     = try(var.https_listeners[count.index]["alpn_policy"], "")
+  alpn_policy     = try(var.encrypted_listeners[count.index]["alpn_policy"], null)
 
   dynamic "default_action" {
     for_each = length(keys(var.https_listeners[count.index])) == 0 ? [] : [var.https_listeners[count.index]]

--- a/main.tf
+++ b/main.tf
@@ -412,7 +412,7 @@ resource "aws_lb_listener" "frontend_https" {
   protocol        = lookup(var.https_listeners[count.index], "protocol", "HTTPS")
   certificate_arn = var.https_listeners[count.index]["certificate_arn"]
   ssl_policy      = lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)
-  alpn_policy     = lookup(var.encrypted_listeners[count.index]["alpn_policy"], null)
+  alpn_policy     = try(var.https_listeners[count.index]["alpn_policy"], "")
 
   dynamic "default_action" {
     for_each = length(keys(var.https_listeners[count.index])) == 0 ? [] : [var.https_listeners[count.index]]

--- a/main.tf
+++ b/main.tf
@@ -412,6 +412,7 @@ resource "aws_lb_listener" "frontend_https" {
   protocol        = lookup(var.https_listeners[count.index], "protocol", "HTTPS")
   certificate_arn = var.https_listeners[count.index]["certificate_arn"]
   ssl_policy      = lookup(var.https_listeners[count.index], "ssl_policy", var.listener_ssl_policy_default)
+  alpn_policy     = lookup(var.encrypted_listeners[count.index]["alpn_policy"], null)
 
   dynamic "default_action" {
     for_each = length(keys(var.https_listeners[count.index])) == 0 ? [] : [var.https_listeners[count.index]]


### PR DESCRIPTION
## Description
I have a project on my company where we needed to be able to set ALPN policies for the target group attachments since we support some legacy apps. I added the Ability to add that value inside the map that you send to the module:


```
{
    action_type        = "forward"
    port               = 443
    protocol           = "TLS"
    target_group_index = 2
    certificate_arn    = "arn:aws:acm:us-west-2:1234567890:certificate/b123456789...."
    alpn_policy        = "HTTP2Optional"
 }
```

## Motivation and Context
It adds capacity to map ALPN policies to target groups.


## How Has This Been Tested?
- I tested this change in my enviornment and it is working as expected using NLB's.

The plan now outputs to this when the alpn_policy is set:

```
https_listeners = [
  {
    action_type        = "forward"
    port               = 443
    protocol           = "TLS"
    target_group_index = 2
    certificate_arn    = "arn:aws:acm:us-west-2:807760185374:certificate/b2966644-3dfc-4fc7-b84a-522012a5feb1"
    alpn_policy        = "HTTP2Optional"
  }
]
```

```
  + resource "aws_lb_listener" "frontend_https" {
      + alpn_policy       = "HTTP2Optional"
      + arn               = (known after apply)
      + certificate_arn   = "arn:aws:acm:us-west-2:807760185374:certificate/b2966644-3dfc-4fc7-b84a-522012a5feb1"
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 443
      + protocol          = "TLS"
      + ssl_policy        = (known after apply)
      + tags_all          = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }
```

```
https_listeners = [
  {
    action_type        = "forward"
    port               = 443
    protocol           = "TLS"
    target_group_index = 2
    certificate_arn    = "arn:aws:acm:us-west-2:807760185374:certificate/b2966644-3dfc-4fc7-b84a-522012a5feb1"
  }
]
```

```
  # aws_lb_listener.front_encrypted[0] will be created
  + resource "aws_lb_listener" "frontend_https" {
      + arn               = (known after apply)
      + certificate_arn   = "arn:aws:acm:us-west-2:807760185374:certificate/b2966644-3dfc-4fc7-b84a-522012a5feb1"
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 443
      + protocol          = "TLS"
      + ssl_policy        = (known after apply)
      + tags_all          = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }
```

