### PR TITLE
fix: Remove not required depends_on in aws_lb_target_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,8 +107,6 @@ resource "aws_lb_target_group" "main" {
     },
   )
 
-  depends_on = [aws_lb.this]
-
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
It has been introduced in this PR but I do not see any reason for it. A target group can be created without a lb.
https://github.com/terraform-aws-modules/terraform-aws-alb/pull/37/

In the following PR, some depends_on have been removed but not this one:
https://github.com/terraform-aws-modules/terraform-aws-alb/pull/49

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
