### PR TITLE
feat: Added `weighted-forward` rules for HTTP

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.67.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ It's recommended you use this module with [terraform-aws-vpc](https://registry.t
 
 ## Notes
 
-1. Terraform AWS provider >= v2.39.0 (via Terraform >= 0.12) has [issue #16674](https://github.com/hashicorp/terraform-provider-aws/issues/16674) related to "Provider produced inconsistent final plan". It means that S3 bucket has to be created before referencing it as an argument inside `access_logs = { bucket = "my-already-created-bucket-for-logs" }`, so this won't work: `access_logs = { bucket = module.log_bucket.s3_bucket_id }`.
+1. Terraform AWS provider version v2.39.0 and newer has [issue #16674](https://github.com/hashicorp/terraform-provider-aws/issues/16674) related to "Provider produced inconsistent final plan". It means that S3 bucket has to be created before referencing it as an argument inside `access_logs = { bucket = "my-already-created-bucket-for-logs" }`, so this won't work: `access_logs = { bucket = module.log_bucket.s3_bucket_id }`.
 
 ## Conditional creation
 

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -38,7 +38,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../ | n/a |
-| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 2.0 |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 3.0 |
 | <a name="module_lb_disabled"></a> [lb\_disabled](#module\_lb\_disabled) | ../../ | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 
@@ -54,7 +54,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -313,6 +313,35 @@ module "alb" {
           values           = ["yes", "please", "right now"]
         }]
       }]
+    },    
+    {
+      http_tcp_listener_index = 0
+      priority                = 4
+
+      actions = [{
+        type = "weighted-forward"
+        target_groups = [
+          {
+            target_group_index = 1
+            weight             = 2
+          },
+          {
+            target_group_index = 0
+            weight             = 1
+          }
+        ]
+        stickiness = {
+          enabled  = true
+          duration = 3600
+        }
+      }]
+
+      conditions = [{
+        query_strings = [{
+          key   = "weighted"
+          value = "true"
+        }]
+      }]
     },
     {
       http_tcp_listener_index = 0

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -13,8 +13,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 resource "random_pet" "this" {
@@ -38,21 +41,21 @@ module "security_group" {
   egress_rules        = ["all-all"]
 }
 
-# module "log_bucket" {
-#   source  = "terraform-aws-modules/s3-bucket/aws"
-#   version = "~> 1.0"
+#module "log_bucket" {
+#  source  = "terraform-aws-modules/s3-bucket/aws"
+#  version = "~> 3.0"
 #
-#   bucket                         = "logs-${random_pet.this.id}"
-#   acl                            = "log-delivery-write"
-#   force_destroy                  = true
-#   attach_elb_log_delivery_policy = true
-# }
+#  bucket                         = "logs-${random_pet.this.id}"
+#  acl                            = "log-delivery-write"
+#  force_destroy                  = true
+#  attach_elb_log_delivery_policy = true
+#}
 
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 3.0"
 
-  domain_name = local.domain_name # trimsuffix(data.aws_route53_zone.this.name, ".") # Terraform >= 0.12.17
+  domain_name = local.domain_name # trimsuffix(data.aws_route53_zone.this.name, ".")
   zone_id     = data.aws_route53_zone.this.id
 }
 
@@ -90,7 +93,7 @@ module "alb" {
 
   vpc_id          = data.aws_vpc.default.id
   security_groups = [module.security_group.security_group_id]
-  subnets         = data.aws_subnet_ids.all.ids
+  subnets         = data.aws_subnets.all.ids
 
   #   # See notes in README (ref: https://github.com/terraform-providers/terraform-provider-aws/issues/7987)
   #   access_logs = {
@@ -313,7 +316,7 @@ module "alb" {
           values           = ["yes", "please", "right now"]
         }]
       }]
-    },    
+    },
     {
       http_tcp_listener_index = 0
       priority                = 4
@@ -499,7 +502,7 @@ resource "null_resource" "download_package" {
 
 module "lambda_function" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -34,7 +34,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | n/a |
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
 | <a name="module_nlb"></a> [nlb](#module\_nlb) | ../../ | n/a |
 
 ## Resources
@@ -44,7 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -22,14 +22,13 @@ resource "aws_lb" "this" {
   enable_waf_fail_open             = var.enable_waf_fail_open
   desync_mitigation_mode           = var.desync_mitigation_mode
 
-  # See notes in README (ref: https://github.com/terraform-providers/terraform-provider-aws/issues/7987)
   dynamic "access_logs" {
     for_each = length(keys(var.access_logs)) == 0 ? [] : [var.access_logs]
 
     content {
-      enabled = lookup(access_logs.value, "enabled", lookup(access_logs.value, "bucket", null) != null)
-      bucket  = lookup(access_logs.value, "bucket", null)
-      prefix  = lookup(access_logs.value, "prefix", null)
+      enabled = try(access_logs.value.enabled, try(access_logs.value.bucket, null) != null)
+      bucket  = try(access_logs.value.bucket, null)
+      prefix  = try(access_logs.value.prefix, null)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -450,6 +450,37 @@ resource "aws_lb_listener_rule" "http_tcp_listener_rule" {
     }
   }
 
+  # weighted forward actions
+  dynamic "action" {
+    for_each = [
+      for action_rule in var.http_tcp_listener_rules[count.index].actions :
+      action_rule
+      if action_rule.type == "weighted-forward"
+    ]
+
+    content {
+      type = "forward"
+      forward {
+        dynamic "target_group" {
+          for_each = action.value["target_groups"]
+
+          content {
+            arn    = aws_lb_target_group.main[target_group.value["target_group_index"]].id
+            weight = target_group.value["weight"]
+          }
+        }
+        dynamic "stickiness" {
+          for_each = [lookup(action.value, "stickiness", {})]
+
+          content {
+            enabled  = try(stickiness.value["enabled"], false)
+            duration = try(stickiness.value["duration"], 1)
+          }
+        }
+      }
+    }
+  }
+
   # Path Pattern condition
   dynamic "condition" {
     for_each = [


### PR DESCRIPTION
## Description
This PR add 'weighted-forward' dynamic action block to use with the _http_tcp_listener_rule_ for multiple weighted target_group.
It is very close to #224 but manage the http.

## Motivation and Context
This adds a dynamic action block for a "weighted-forward" action_rule.type for the http_tcp_listener_rules . It allows us to create a listener rule like:

```
{
  http_tcp_listener_index = 0
  priority                = 30

  actions = [
    {
      type = "weighted-forward"
      target_groups = [
        {
          target_group_index = 1
          weight             = 1
        },
        {
          target_group_index = 0
          weight             = 0
        }
      ]
    }
  ]

  conditions = [{}]
}
```

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects

I created the resources and visually verified the correct rules made it onto the load balancer.
```
+ forward {
  + stickiness {
    + duration = 0
    + enabled  = false
  }
  
  + target_group {
    + arn    = "arn:aws:elasticloadbalancing:eu-west-1:../21b716c2bd84930d"
    + weight = 1
  }
  + target_group {
    + arn    = "arn:aws:elasticloadbalancing:eu-west-1:../6c33705a9ab0897a"
    + weight = 2
  }
}
```
