### PR TITLE
feat: Added support for lambda permissions when the target is a lambda function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.67.0
+    rev: v1.71.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -69,79 +69,6 @@ module "alb" {
 }
 ```
 
-HTTP and HTTPS listeners to lambda:
-
-The targets block has 7 attributes specific to lambda. The details about available here [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission#action](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission#action)
-
-| Name                        | Default                              | Required |
-|-----------------------------|--------------------------------------|----------|
-| `lambda_function_name`      |                                      | `yes`    |
-| `lambda_action`             | `lambda:InvokeFunction`              | `no`     |
-| `lambda_event_source_token` | `null`                               | `no`     |
-| `lambda_principal`          | `elasticloadbalancing.amazonaws.com` | `no`     |
-| `lambda_qualifier`          | `null`                               | `no`     |
-| `lambda_source_account`     | `null`                               | `no`     |
-| `lambda_statement_id`       | `AllowExecutionFromLb`               | `no`     |
-
-
-```hcl
-module "alb" {
-  source  = "terraform-aws-modules/alb/aws"
-  version = "~> 6.0"
-
-  name = "my-alb"
-
-  load_balancer_type = "application"
-
-  vpc_id             = "vpc-abcde012"
-  subnets            = ["subnet-abcde012", "subnet-bcde012a"]
-  security_groups    = ["sg-edcd9784", "sg-edcd9785"]
-
-  access_logs = {
-    bucket = "my-alb-logs"
-  }
-
-  target_groups = [
-    {
-      name_prefix      = "l1-"
-      target_type      = "lambda"
-      lambda_multi_value_headers_enabled = true
-      targets = {
-        my_lambda = {
-          target_id = "i-0123456789abcdefg"
-          lambda_function_name = "my_lambda_function_name"
-        }
-        my_other_lambda = {
-          target_id = "i-a1b2c3d4e5f6g7h8i"
-          lambda_function_name = "my_other_lambda_function_name"
-        }
-      }
-    }
-  ]
-
-  https_listeners = [
-    {
-      port               = 443
-      protocol           = "HTTPS"
-      certificate_arn    = "arn:aws:iam::123456789012:server-certificate/test_cert-123456789012"
-      target_group_index = 0
-    }
-  ]
-
-  http_tcp_listeners = [
-    {
-      port               = 80
-      protocol           = "HTTP"
-      target_group_index = 0
-    }
-  ]
-
-  tags = {
-    Environment = "Test"
-  }
-}
-```
-
 HTTP to HTTPS redirect and HTTPS cognito authentication:
 
 ```hcl
@@ -384,7 +311,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_lambda_permission.with_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_permission.lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lb.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.frontend_http_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.frontend_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -38,7 +38,8 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../ | n/a |
-| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 3.0 |
+| <a name="module_lambda_with_allowed_triggers"></a> [lambda\_with\_allowed\_triggers](#module\_lambda\_with\_allowed\_triggers) | terraform-aws-modules/lambda/aws | ~> 3.0 |
+| <a name="module_lambda_without_allowed_triggers"></a> [lambda\_without\_allowed\_triggers](#module\_lambda\_without\_allowed\_triggers) | terraform-aws-modules/lambda/aws | ~> 3.0 |
 | <a name="module_lb_disabled"></a> [lb\_disabled](#module\_lb\_disabled) | ../../ | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -373,13 +373,9 @@ module "alb" {
       target_type                        = "lambda"
       lambda_multi_value_headers_enabled = true
       targets = {
-        # Lambda function permission should be granted before
-        # it is used. There can be an error:
-        # NB: Error registering targets with target group:
-        # AccessDenied: elasticloadbalancing principal does not
-        # have permission to invoke ... from target group ...
         my_lambda = {
-          target_id = module.lambda_function.lambda_function_arn
+          target_id            = module.lambda_function.lambda_function_arn
+          lambda_function_name = module.lambda_function.lambda_function_name
         }
       }
     },

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -478,12 +478,5 @@ module "lambda_function" {
   create_package         = false
   local_existing_package = local.downloaded
 
-  allowed_triggers = {
-    AllowExecutionFromELB = {
-      service    = "elasticloadbalancing"
-      source_arn = module.alb.target_group_arns[1] # index should match the correct target_group
-    }
-  }
-
   depends_on = [null_resource.download_package]
 }

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -405,9 +405,18 @@ module "alb" {
       target_type                        = "lambda"
       lambda_multi_value_headers_enabled = true
       targets = {
-        my_lambda = {
-          target_id            = module.lambda_function.lambda_function_arn
-          lambda_function_name = module.lambda_function.lambda_function_name
+        lambda_with_allowed_triggers = {
+          target_id = module.lambda_with_allowed_triggers.lambda_function_arn
+        }
+      }
+    },
+    {
+      name_prefix = "l2-"
+      target_type = "lambda"
+      targets = {
+        lambda_without_allowed_triggers = {
+          target_id                = module.lambda_without_allowed_triggers.lambda_function_arn
+          attach_lambda_permission = true
         }
       }
     },
@@ -496,12 +505,12 @@ resource "null_resource" "download_package" {
   }
 }
 
-module "lambda_function" {
+module "lambda_with_allowed_triggers" {
   source  = "terraform-aws-modules/lambda/aws"
   version = "~> 3.0"
 
-  function_name = "${random_pet.this.id}-lambda"
-  description   = "My awesome lambda function"
+  function_name = "${random_pet.this.id}-with-allowed-triggers"
+  description   = "My awesome lambda function (with allowed triggers)"
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
@@ -509,6 +518,33 @@ module "lambda_function" {
 
   create_package         = false
   local_existing_package = local.downloaded
+
+  allowed_triggers = {
+    AllowExecutionFromELB = {
+      service    = "elasticloadbalancing"
+      source_arn = module.alb.target_group_arns[1] # index should match the correct target_group
+    }
+  }
+
+  depends_on = [null_resource.download_package]
+}
+
+module "lambda_without_allowed_triggers" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 3.0"
+
+  function_name = "${random_pet.this.id}-without-allowed-triggers"
+  description   = "My awesome lambda function (without allowed triggers)"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+
+  publish = true
+
+  create_package         = false
+  local_existing_package = local.downloaded
+
+  # Allowed triggers will be managed by ALB module
+  allowed_triggers = {}
 
   depends_on = [null_resource.download_package]
 }

--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,31 @@ locals {
       if k == "targets"
     ]
   ])...)
+
+  # Filter out the attachments for lambda functions. The ALB target group needs permission to forward a request on to
+  # the specified lambda function. This filtered list is used to create those permission resources
+  target_group_attachments_lambda = merge(flatten([
+    for target_group_attachments_key, target_group_attachments_value in local.target_group_attachments : [
+      for k, v in target_group_attachments_value : { (target_group_attachments_key) = target_group_attachments_value }
+      if k == "lambda_function_name"
+    ]
+  ])...)
+}
+
+resource "aws_lambda_permission" "with_lb" {
+  for_each = var.create_lb && local.target_group_attachments_lambda != null ? local.target_group_attachments_lambda : {}
+
+  # required
+  function_name = each.value.lambda_function_name
+
+  # optional
+  action             = lookup(each.value, "lambda_action", null) != null ? each.value.lambda_action : "lambda:InvokeFunction"
+  event_source_token = lookup(each.value, "lambda_event_source_token", null)
+  principal          = lookup(each.value, "lambda_principal", null) != null ? each.value.lambda_principal : "elasticloadbalancing.amazonaws.com"
+  qualifier          = lookup(each.value, "lambda_qualifier", null)
+  source_account     = lookup(each.value, "lambda_source_account", null)
+  source_arn         = aws_lb_target_group.main[each.value.tg_index].arn
+  statement_id       = lookup(each.value, "lambda_statement_id", null) != null ? each.value.lambda_statement_id : "AllowExecutionFromLb"
 }
 
 resource "aws_lb_target_group_attachment" "this" {
@@ -138,6 +163,8 @@ resource "aws_lb_target_group_attachment" "this" {
   target_id         = each.value.target_id
   port              = lookup(each.value, "port", null)
   availability_zone = lookup(each.value, "availability_zone", null)
+
+  depends_on = [aws_lambda_permission.with_lb]
 }
 
 resource "aws_lb_listener_rule" "https_listener_rule" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR adds the `aws_lambda_permission` resource that should be created before the `aws_lb_target_group_attachment` is created.

`target_groups.targets` is extended to allow `aws_lambda_permission` attributes to be passed in. The new attributes are listed under the top level of `target_groups.target` which makes the structure very flat. The ideal case would nest those within a `target_groups.target.lambda_permissions` however this is not possible as it leads to this problem [https://github.com/hashicorp/terraform/issues/22405](https://github.com/hashicorp/terraform/issues/22405)

The trigger on the lambda resource is also removed from the complete example as it is unnecessary now

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The problem was that the lambda ARN is an input to the module. However, to create the permissions for the target group to to target the lambda, you needed the output target group ARN. The workaround was to run `terraform apply` twice.

Now, the permission fields can be passed into the module and the module creates the permission resources required if `attach_lambda_permission = true` in `targets`.

This refers to #210 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

It does not break backward compatibility. 

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been added and tested against the complete ALB example where there is a mix of target types. 