### PR TITLE
feat: Added missing `cookie_name` TG stickiness parameter support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,7 @@ resource "aws_lb_target_group" "main" {
       enabled         = lookup(stickiness.value, "enabled", null)
       cookie_duration = lookup(stickiness.value, "cookie_duration", null)
       type            = lookup(stickiness.value, "type", null)
+      cookie_name     = lookup(stickiness.value, "cookie_name", null)
     }
   }
 


### PR DESCRIPTION
## Description
Adding optional `cookie_name` parameter support for the target group stickiness. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#cookie_name

## Motivation and Context
We have got an issue while trying to provision ALB with TG stickiness type `app_cookie` due to a lack of `cookie_name` parameter support.
Fixes #242

## Breaking Changes
We are not aware of breaking changes. Changes should be backward compatible(one optional parameter support added)

## How Has This Been Tested?
- We have tested changes by creating TGs with stickiness types `lb_cookie` and `app_cookie`