### PR TITLE
feat!: Add support for preserve_host_header

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "aws_lb" "this" {
   drop_invalid_header_fields       = var.drop_invalid_header_fields
   enable_waf_fail_open             = var.enable_waf_fail_open
   desync_mitigation_mode           = var.desync_mitigation_mode
+  preserve_host_header             = var.preserve_host_header
 
   dynamic "access_logs" {
     for_each = length(keys(var.access_logs)) == 0 ? [] : [var.access_logs]

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,12 @@ variable "desync_mitigation_mode" {
   default     = "defensive"
 }
 
+variable "preserve_host_header" {
+  description = "Indicates whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change"
+  type        = bool
+  default     = false
+}
+
 variable "putin_khuylo" {
   description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
   type        = bool


### PR DESCRIPTION
## Description

Adds https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#preserve_host_header

## Motivation and Context
Argument is supported by there is no option to disable it in this module. 

## Important 
We wish to add this to version `6.x` since we user a lower aws provider version

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
