### PR TITLE
fix: Allow for override of Name tag on load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,11 +44,11 @@ resource "aws_lb" "this" {
   }
 
   tags = merge(
+    {
+      Name = (var.name != null) ? var.name : var.name_prefix
+    },
     var.tags,
     var.lb_tags,
-    {
-      Name = var.name != null ? var.name : var.name_prefix
-    },
   )
 
   timeouts {


### PR DESCRIPTION
## Description
Changes the order of `merge()` on the tags to allow override of the `Name` tag.

## Motivation and Context

I prefer to use `name_prefix` when creating load balancers. This ensures all the load balancers are created with unique names. However, it becomes difficult to determine which load balancer I am viewing in the AWS console because they are start with the same prefix. The only way to see which one I am looking at is to review the rules. 

My solution is to use a `Name` tag passed into the variable `lb_tags`. This module currently overrides any `Name` tag I pass with the value of `name_prefix`. By changing the order of the `merge()` on the tags, the module can still set `Name` if it is not passed in, but won't override it if it is.

This PR is loosely related to #52.

## Breaking Changes
There is no breaking changes in this PR.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

I deployed a load balancer using this module, version 8.1, with `lb_tags = { "Name" = "MyLoadBalancer" }` and the `name_prefix = "mylb-"`. After I deployed the load balancer, the `Name` tag was defined as `mylb-`. I switched the module source in my terraform to use my feature branch and ran terraform apply. The `Name` tag was updated to `MyLoadBalancer`

- [x] I have executed `pre-commit run -a` on my pull request
