### PR TITLE
docs: Added stickiness to examples and README

### DIFF
--- a/examples/complete-nlb/main.tf
+++ b/examples/complete-nlb/main.tf
@@ -113,6 +113,10 @@ module "nlb" {
       target_type            = "instance"
       connection_termination = true
       preserve_client_ip     = true
+      stickiness = {
+        enabled = true
+        type    = "source_ip"
+      }
       tags = {
         tcp_udp = true
       }


### PR DESCRIPTION
## Description
Added stickiness in complete-nlb example

## Motivation and Context
Stickiness was missing in the example and hence would take some time for other users to be able to use it
on this module.

## Breaking Changes
No breaking changes as modification was done in examples/ only
