### PR TITLE
fix: make vpc_id null when target_type lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_lb_target_group" "main" {
   name        = lookup(var.target_groups[count.index], "name", null)
   name_prefix = lookup(var.target_groups[count.index], "name_prefix", null)
 
-  vpc_id           = var.vpc_id
+  vpc_id           = lookup(var.target_groups[count.index], "target_type", var.vpc_id) == "lambda" ? null : var.vpc_id
   port             = lookup(var.target_groups[count.index], "backend_port", null)
   protocol         = lookup(var.target_groups[count.index], "backend_protocol", null) != null ? upper(lookup(var.target_groups[count.index], "backend_protocol")) : null
   protocol_version = lookup(var.target_groups[count.index], "protocol_version", null) != null ? upper(lookup(var.target_groups[count.index], "protocol_version")) : null


### PR DESCRIPTION
## Description


## Motivation and Context
Resolves https://github.com/terraform-aws-modules/terraform-aws-alb/issues/232

## Breaking Changes
None

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
