### PR TITLE
feat: Default action forward action type

### DIFF
--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -76,6 +76,23 @@ module "alb" {
     {
       port        = 81
       protocol    = "HTTP"
+      action_type = "forward"
+      forward = {
+        target_groups = [
+          {
+            target_group_index = 0
+            weight             = 100
+          },
+          {
+            target_group_index = 1
+            weight             = 0
+          }
+        ]
+      }
+    },
+    {
+      port        = 82
+      protocol    = "HTTP"
       action_type = "redirect"
       redirect = {
         port        = "443"
@@ -84,7 +101,7 @@ module "alb" {
       }
     },
     {
-      port        = 82
+      port        = 83
       protocol    = "HTTP"
       action_type = "fixed-response"
       fixed_response = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
feat: default-action forward action type

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 AWS Code Deploy Blue/Green Deployment automatically register 2 target group for 1 application. The first one is blue target group, and the other is green target group.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
```
  http_tcp_listeners = [
    {
      port     = 80
      protocol = "HTTP"
      action_type = "forward"
      forward = {
        target_groups = [
          {
            target_group_index = 0
            weight             = 100
          },
          {
            target_group_index = 1
            weight             = 0
          }
        ]
      }
    }
  ]
```