### PR TITLE
fix: Make vpc_id null when target_type lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_lb_target_group" "main" {
   name        = lookup(var.target_groups[count.index], "name", null)
   name_prefix = lookup(var.target_groups[count.index], "name_prefix", null)
 
-  vpc_id           = var.vpc_id
+  vpc_id           = lookup(var.target_groups[count.index], "target_type", null) == "lambda" ? null : var.vpc_id
   port             = lookup(var.target_groups[count.index], "backend_port", null)
   protocol         = lookup(var.target_groups[count.index], "backend_protocol", null) != null ? upper(lookup(var.target_groups[count.index], "backend_protocol")) : null
   protocol_version = lookup(var.target_groups[count.index], "protocol_version", null) != null ? upper(lookup(var.target_groups[count.index], "protocol_version")) : null


### PR DESCRIPTION
## Description
We want to be able to use the ALB module to create lambda target types without VPC.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have an ALB which has a listener rule which has lambda as target.  We do not want VPC Id when target type is lambda
<!--- If it fixes an open issue, please link to the issue here. -->
The PR fixes [this issue](https://github.com/terraform-aws-modules/terraform-aws-alb/issues/232)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No breaking changes
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s) _(There's already an example with lambda target type)_
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects _(We have tested this change with our use case where we only want lambda target without VPC_
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
