### PR TITLE
fix: Correct stickiness syntax and ensure that security group is not created for network load balancers

### DIFF
--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -57,7 +57,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name for which the certificate should be issued | `string` | `"terraform-aws-modules.modules.tf"` | no |
 
 ## Outputs
 

--- a/examples/complete-alb/variables.tf
+++ b/examples/complete-alb/variables.tf
@@ -1,0 +1,5 @@
+variable "domain_name" {
+  description = "The domain name for which the certificate should be issued"
+  type        = string
+  default     = "terraform-aws-modules.modules.tf"
+}

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -21,14 +21,12 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.27 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.27 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
@@ -36,20 +34,21 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
 | <a name="module_nlb"></a> [nlb](#module\_nlb) | ../../ | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
-| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
-| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name for which the certificate should be issued | `string` | `"terraform-aws-modules.modules.tf"` | no |
 
 ## Outputs
 

--- a/examples/complete-nlb/variables.tf
+++ b/examples/complete-nlb/variables.tf
@@ -1,0 +1,5 @@
+variable "domain_name" {
+  description = "The domain name for which the certificate should be issued"
+  type        = string
+  default     = "terraform-aws-modules.modules.tf"
+}

--- a/examples/complete-nlb/versions.tf
+++ b/examples/complete-nlb/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.27"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.0"
-    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_lb" "this" {
 
   load_balancer_type = var.load_balancer_type
   internal           = var.internal
-  security_groups    = var.create_security_group ? concat([aws_security_group.this[0].id], var.security_groups) : var.security_groups
+  security_groups    = var.create_security_group && var.load_balancer_type == "application" ? concat([aws_security_group.this[0].id], var.security_groups) : var.security_groups
   subnets            = var.subnets
 
   idle_timeout                     = var.idle_timeout
@@ -100,10 +100,10 @@ resource "aws_lb_target_group" "main" {
     for_each = try([var.target_groups[count.index].stickiness], [])
 
     content {
-      enabled         = lookup(stickiness.value.enabled, null)
-      cookie_duration = lookup(stickiness.value.cookie_duration, null)
-      type            = lookup(stickiness.value.type, null)
-      cookie_name     = lookup(stickiness.value.cookie_name, null)
+      enabled         = try(stickiness.value.enabled, null)
+      cookie_duration = try(stickiness.value.cookie_duration, null)
+      type            = try(stickiness.value.type, null)
+      cookie_name     = try(stickiness.value.cookie_name, null)
     }
   }
 
@@ -770,7 +770,7 @@ resource "aws_lb_listener_certificate" "https_listener" {
 ################################################################################
 
 locals {
-  create_security_group = local.create_lb && var.create_security_group
+  create_security_group = local.create_lb && var.create_security_group && var.load_balancer_type == "application"
   security_group_name   = try(coalesce(var.security_group_name, var.name, var.name_prefix), "")
 }
 


### PR DESCRIPTION
## Description
- Correct stickiness syntax and ensure that security group is not created for network load balancers
- Update examples to allow other users to test with a domain and align example usage

## Motivation and Context
- Resolves #276 
- Resolves #275 

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
