### PR TITLE
Allow overwriting of security group tag "Name"

### DIFF
--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -413,6 +413,7 @@ module "alb" {
   ]
 
   tags = {
+    Name    = "foo-bar"
     Project = "Unknown"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -811,9 +811,9 @@ resource "aws_security_group" "this" {
   vpc_id      = var.vpc_id
 
   tags = merge(
+    { "Name" = local.security_group_name },
     var.tags,
     var.security_group_tags,
-    { "Name" = local.security_group_name },
   )
 
   lifecycle {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change allows the `Name` security group tag to be changed. The current implementation of tag merge order will always set tag `Name == var.security_group_name`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'd like to have terraform generate my security group name. To accomplish this, I've set `var.security_group_use_name_prefix = true` and `var.security_group_name = terraform`. This causes the tag `Name` to be set to `terraform`, which is not very descriptive. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This will change the `Name` tag if it has been passed as a var and it does not match `var.security_group_name`


## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->