### PR TITLE
docs: Add lambda_function_arn format for lambda_function_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,9 @@ locals {
   ])...)
 
   # Filter out the attachments for lambda functions. The ALB target group needs permission to forward a request on to
-  # the specified lambda function. This filtered list is used to create those permission resources
+  # the specified lambda function. This filtered list is used to create those permission resources.
+  # To get the lambda_function_name, the 6th index is taken from the lambda_function_arn format below
+  # arn:aws:lambda:<region>:<account-id>:function:my-function-name:<version-number>
   target_group_attachments_lambda = {
     for k, v in local.target_group_attachments :
     (k) => merge(v, { lambda_function_name = split(":", v.target_id)[6] })


### PR DESCRIPTION
## Description
Add comment explaining 6th index after split function in lambda_function_name value.

## Motivation and Context
Lambda function ARN format is not specified in the comments so it is quite confusing why 6th index is taken as the lambda_function_name value

## Breaking Changes
This does not have breaking changes and is backward compatible. Only comments are added.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
