### PR TITLE
feat: Add forward group for https listener

### DIFF
--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -164,6 +164,23 @@ module "alb" {
         user_info_endpoint     = "https://${var.domain_name}/user_info"
       }
     },
+    {
+      port            = 446
+      protocol        = "HTTPS"
+      certificate_arn = module.acm.acm_certificate_arn
+      forward = {
+        target_groups = [
+          {
+            target_group_index = 0
+            weight             = 1
+          },
+          {
+            target_group_index = 1
+            weight             = 0
+          }
+        ]
+      }
+    },
   ]
 
   extra_ssl_certs = [

--- a/main.tf
+++ b/main.tf
@@ -710,7 +710,7 @@ resource "aws_lb_listener" "frontend_https" {
     # Defaults to forward action if action_type not specified
     content {
       type             = lookup(default_action.value, "action_type", "forward")
-      target_group_arn = contains([null, "", "forward"], lookup(default_action.value, "action_type", "")) ? aws_lb_target_group.main[lookup(default_action.value, "target_group_index", count.index)].id : null
+      target_group_arn = contains([null, "", "forward"], lookup(default_action.value, "action_type", "")) && length(keys(lookup(default_action.value, "forward", {}))) == 0 ? aws_lb_target_group.main[lookup(default_action.value, "target_group_index", count.index)].id : null
 
       dynamic "redirect" {
         for_each = length(keys(lookup(default_action.value, "redirect", {}))) == 0 ? [] : [lookup(default_action.value, "redirect", {})]
@@ -732,6 +732,30 @@ resource "aws_lb_listener" "frontend_https" {
           content_type = fixed_response.value["content_type"]
           message_body = lookup(fixed_response.value, "message_body", null)
           status_code  = lookup(fixed_response.value, "status_code", null)
+        }
+      }
+
+      dynamic "forward" {
+        for_each = length(keys(lookup(default_action.value, "forward", {}))) == 0 ? [] : [lookup(default_action.value, "forward", {})]
+
+        content {
+          dynamic "target_group" {
+            for_each = forward.value["target_groups"]
+
+            content {
+              arn    = aws_lb_target_group.main[target_group.value["target_group_index"]].id
+              weight = lookup(target_group.value, "weight", null)
+            }
+          }
+
+          dynamic "stickiness" {
+            for_each = length(keys(lookup(forward.value, "stickiness", {}))) == 0 ? [] : [lookup(forward.value, "stickiness", {})]
+
+            content {
+              enabled  = lookup(stickiness.value, "enabled", false)
+              duration = lookup(stickiness.value, "duration", 60)
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Description
Add ability to define forward groups for HTTPS listeners. 

## Motivation and Context
Blue/Green ECS deployments with AWS Codepipelines. Similar to #269 

## Breaking Changes
There is no breaking changes but I added a check in **default_action** block for **forward/empty** action to make sure that only target_group_arn or forward group is defined for that block but not both

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
