### PR TITLE
fix: Argument `target_group_arn` should not be defined if listener type is `forward` and traffic needs to be routed to multiple target groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -635,7 +635,8 @@ resource "aws_lb_listener" "frontend_http_tcp" {
     # Defaults to forward action if action_type not specified
     content {
       type             = lookup(default_action.value, "action_type", "forward")
-      target_group_arn = contains([null, "", "forward"], lookup(default_action.value, "action_type", "")) ? aws_lb_target_group.main[lookup(default_action.value, "target_group_index", count.index)].id : null
+      target_group_arn = contains([null, "", "forward"], lookup(default_action.value, "action_type", "")) && length(lookup(lookup(default_action.value, "forward", {}), "target_groups", [])) < 2 ? aws_lb_target_group.main[lookup(default_action.value, "target_group_index", count.index)].id : null
+
 
       dynamic "redirect" {
         for_each = length(keys(lookup(default_action.value, "redirect", {}))) == 0 ? [] : [lookup(default_action.value, "redirect", {})]
@@ -710,7 +711,7 @@ resource "aws_lb_listener" "frontend_https" {
     # Defaults to forward action if action_type not specified
     content {
       type             = lookup(default_action.value, "action_type", "forward")
-      target_group_arn = contains([null, "", "forward"], lookup(default_action.value, "action_type", "")) ? aws_lb_target_group.main[lookup(default_action.value, "target_group_index", count.index)].id : null
+      target_group_arn = contains([null, "", "forward"], lookup(default_action.value, "action_type", "")) && length(lookup(lookup(default_action.value, "forward", {}), "target_groups", [])) < 2 ? aws_lb_target_group.main[lookup(default_action.value, "target_group_index", count.index)].id : null
 
       dynamic "redirect" {
         for_each = length(keys(lookup(default_action.value, "redirect", {}))) == 0 ? [] : [lookup(default_action.value, "redirect", {})]


### PR DESCRIPTION


## Description
Fixes #299

## Motivation and Context
Fixes bug that currently makes weighted target groups not to work as expected, documented more in-depth in the issue above. 

## Breaking Changes
No

## How Has This Been Tested?
I have tested this module with a listener that is using weighted target groups, like the one provided in the examples
https://github.com/terraform-aws-modules/terraform-aws-alb/blob/cb8e43d456a863e954f6b97a4a821f41d4280ab8/examples/complete-alb/main.tf#L82-L98

Now, when more than 1 target group is defined, the default `target_group_arn` is removed, and the target groups are configured as expected in the `forward` block
```
      ~ default_action {
          - target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:012345678912:targetgroup/MY-TARGET-GROUP-1/x0x0x0x0x0x0x" -> null
            # (2 unchanged attributes hidden)

          + forward {
              + stickiness {
                  + duration = 3600
                  + enabled  = true
                }

              + target_group {
                  + arn    = "arn:aws:elasticloadbalancing:us-east-1:012345678912:targetgroup/MY-TARGET-GROUP-1/x0x0x0x0x0x0x"
                  + weight = 100
                }
              + target_group {
                  + arn    = "arn:aws:elasticloadbalancing:us-east-1:012345678912:targetgroup/MY-TARGET-GROUP-2/x0x0x0x0x0x0x"
                  + weight = 0
                }
            }
        }
```
Further apply's don't keep on trying to configure the forward section indefinitely. 

