### PR TITLE
fix lb output descriptions

### DIFF
--- a/examples/complete-alb/outputs.tf
+++ b/examples/complete-alb/outputs.tf
@@ -1,10 +1,10 @@
 output "lb_id" {
-  description = "The ID and ARN of the load balancer we created."
+  description = "The ID of the load balancer we created."
   value       = module.alb.lb_id
 }
 
 output "lb_arn" {
-  description = "The ID and ARN of the load balancer we created."
+  description = "The ARN of the load balancer we created."
   value       = module.alb.lb_arn
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 output "lb_id" {
-  description = "The ID and ARN of the load balancer we created"
+  description = "The ID of the load balancer we created"
   value       = try(aws_lb.this[0].id, "")
 }
 
 output "lb_arn" {
-  description = "The ID and ARN of the load balancer we created"
+  description = "The ARN of the load balancer we created"
   value       = try(aws_lb.this[0].arn, "")
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR changes the output descriptions for `lb_arn` and `lb_id` so that they are clearly explained, instead of being duplicates of each other.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change clarifies the description of the outputs so that it is less confusing.
<!--- If it fixes an open issue, please link to the issue here. -->


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
