### PR TITLE
feat: Add support for disabling connection termination for unhealthy targets and AZ DNS affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,13 +348,13 @@ See [patterns.md](https://github.com/terraform-aws-modules/terraform-aws-alb/blo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.23 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.23 |
 
 ## Modules
 
@@ -390,6 +390,7 @@ No modules.
 | <a name="input_default_port"></a> [default\_port](#input\_default\_port) | Default port used across the listener and target group | `number` | `80` | no |
 | <a name="input_default_protocol"></a> [default\_protocol](#input\_default\_protocol) | Default protocol used across the listener and target group | `string` | `"HTTP"` | no |
 | <a name="input_desync_mitigation_mode"></a> [desync\_mitigation\_mode](#input\_desync\_mitigation\_mode) | Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest` | `string` | `null` | no |
+| <a name="input_dns_record_client_routing_policy"></a> [dns\_record\_client\_routing\_policy](#input\_dns\_record\_client\_routing\_policy) | Indicates how traffic is distributed among the load balancer Availability Zones. Possible values are any\_availability\_zone (default), availability\_zone\_affinity, or partial\_availability\_zone\_affinity. Only valid for network type load balancers. | `string` | `null` | no |
 | <a name="input_drop_invalid_header_fields"></a> [drop\_invalid\_header\_fields](#input\_drop\_invalid\_header\_fields) | Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (`true`) or routed to targets (`false`). The default is `true`. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application` | `bool` | `true` | no |
 | <a name="input_enable_cross_zone_load_balancing"></a> [enable\_cross\_zone\_load\_balancing](#input\_enable\_cross\_zone\_load\_balancing) | If `true`, cross-zone load balancing of the load balancer will be enabled. For application load balancer this feature is always enabled (`true`) and cannot be disabled. Defaults to `true` | `bool` | `true` | no |
 | <a name="input_enable_deletion_protection"></a> [enable\_deletion\_protection](#input\_enable\_deletion\_protection) | If `true`, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to `true` | `bool` | `true` | no |

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.23 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.23 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules

--- a/examples/complete-alb/versions.tf
+++ b/examples/complete-alb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.13"
+      version = ">= 5.23"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.23 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.23 |
 
 ## Modules
 

--- a/examples/complete-nlb/main.tf
+++ b/examples/complete-nlb/main.tf
@@ -27,8 +27,9 @@ module "nlb" {
 
   name = local.name
 
-  load_balancer_type = "network"
-  vpc_id             = module.vpc.vpc_id
+  load_balancer_type               = "network"
+  vpc_id                           = module.vpc.vpc_id
+  dns_record_client_routing_policy = "availability_zone_affinity"
 
   # https://github.com/hashicorp/terraform-provider-aws/issues/17281
   # subnets = module.vpc.private_subnets
@@ -158,6 +159,9 @@ module "nlb" {
       port        = 84
       target_type = "instance"
       target_id   = aws_instance.this.id
+      target_health_state = {
+        enable_unhealthy_connection_termination = false
+      }
     }
   }
 

--- a/examples/complete-nlb/versions.tf
+++ b/examples/complete-nlb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.13"
+      version = ">= 5.23"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "aws_lb" "this" {
 
   customer_owned_ipv4_pool                    = var.customer_owned_ipv4_pool
   desync_mitigation_mode                      = var.desync_mitigation_mode
+  dns_record_client_routing_policy            = var.dns_record_client_routing_policy
   drop_invalid_header_fields                  = var.drop_invalid_header_fields
   enable_cross_zone_load_balancing            = var.enable_cross_zone_load_balancing
   enable_deletion_protection                  = var.enable_deletion_protection
@@ -479,6 +480,13 @@ resource "aws_lb_target_group" "this" {
     content {
       on_deregistration = target_failover.value.on_deregistration
       on_unhealthy      = target_failover.value.on_unhealthy
+    }
+  }
+
+  dynamic "target_health_state" {
+    for_each = try([each.value.target_health_state], [])
+    content {
+      enable_unhealthy_connection_termination = try(target_health_state.value.enable_unhealthy_connection_termination, true)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "desync_mitigation_mode" {
   default     = null
 }
 
+variable "dns_record_client_routing_policy" {
+  description = "Indicates how traffic is distributed among the load balancer Availability Zones. Possible values are any_availability_zone (default), availability_zone_affinity, or partial_availability_zone_affinity. Only valid for network type load balancers."
+  type        = string
+  default     = null
+}
+
 variable "drop_invalid_header_fields" {
   description = "Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (`true`) or routed to targets (`false`). The default is `true`. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application`"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.13"
+      version = ">= 5.23"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -11,6 +11,7 @@ module "wrapper" {
   default_port                                = try(each.value.default_port, var.defaults.default_port, 80)
   default_protocol                            = try(each.value.default_protocol, var.defaults.default_protocol, "HTTP")
   desync_mitigation_mode                      = try(each.value.desync_mitigation_mode, var.defaults.desync_mitigation_mode, null)
+  dns_record_client_routing_policy            = try(each.value.dns_record_client_routing_policy, var.defaults.dns_record_client_routing_policy, null)
   drop_invalid_header_fields                  = try(each.value.drop_invalid_header_fields, var.defaults.drop_invalid_header_fields, true)
   enable_cross_zone_load_balancing            = try(each.value.enable_cross_zone_load_balancing, var.defaults.enable_cross_zone_load_balancing, true)
   enable_deletion_protection                  = try(each.value.enable_deletion_protection, var.defaults.enable_deletion_protection, true)


### PR DESCRIPTION
## Description
Add `dns_record_client_routing_policy` to `aws_lb` and `target_health_state` to `aws_lb_target_group`.

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/34070
https://github.com/hashicorp/terraform-provider-aws/issues/33992

## Breaking Changes
No. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
