### PR TITLE
docs: Correct key names for protocol and port in target groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ module "alb" {
   target_groups = {
     ex-instance = {
       name_prefix      = "h1"
-      backend_protocol = "HTTP"
-      backend_port     = 80
+      protocol         = "HTTP"
+      port             = 80
       target_type      = "instance"
     }
   }
@@ -219,10 +219,10 @@ module "alb" {
 
   target_groups = {
     instance = {
-      name_prefix      = "default"
-      backend_protocol = "HTTPS"
-      backend_port     = 443
-      target_type      = "instance"
+      name_prefix = "default"
+      protocol    = "HTTPS"
+      port        = 443
+      target_type = "instance"
     }
   }
 }
@@ -306,10 +306,10 @@ module "nlb" {
 
   target_groups = {
     ex-target = {
-      name_prefix      = "pref-"
-      backend_protocol = "TCP"
-      backend_port     = 80
-      target_type      = "ip"
+      name_prefix = "pref-"
+      protocol    = "TCP"
+      port        = 80
+      target_type = "ip"
     }
   }
 

--- a/UPGRADE-9.0.md
+++ b/UPGRADE-9.0.md
@@ -410,8 +410,8 @@ module "alb" {
   target_groups = [
     {
       name_prefix      = "h1"
-      backend_protocol = "HTTP"
-      backend_port     = 80
+      protocol = "HTTP"
+      port     = 80
       target_type      = "instance"
 
       health_check = {
@@ -793,8 +793,8 @@ module "alb" {
   target_groups = {
     instance = {
       name_prefix      = "h1"
-      backend_protocol = "HTTP"
-      backend_port     = 80
+      protocol = "HTTP"
+      port     = 80
       target_type      = "instance"
 
       health_check = {

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -199,8 +199,8 @@ module "alb" {
     # This key name is used by the listener/listener rules to know which target to forward traffic to
     ex_instance = {
       name_prefix                       = "h1"
-      backend_protocol                  = "HTTP"
-      backend_port                      = 80
+      protocol                          = "HTTP"
+      port                              = 80
       target_type                       = "instance"
       deregistration_delay              = 10
       load_balancing_cross_zone_enabled = true
@@ -292,8 +292,8 @@ module "alb" {
 
   target_groups = {
     ex_ip = {
-      backend_protocol                  = "HTTP"
-      backend_port                      = 80
+      protocol                          = "HTTP"
+      port                              = 80
       target_type                       = "ip"
       deregistration_delay              = 5
       load_balancing_cross_zone_enabled = true

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -348,8 +348,8 @@ module "alb" {
   target_groups = {
     ex-instance = {
       name_prefix                       = "h1"
-      backend_protocol                  = "HTTP"
-      backend_port                      = 80
+      protocol                          = "HTTP"
+      port                              = 80
       target_type                       = "instance"
       deregistration_delay              = 10
       load_balancing_cross_zone_enabled = false


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixing some examples in the documentation. Correct key names for protocol and port in target groups.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The documentation is wrong and may cause confusion when upgrading to version 9.

It's easy to miss this because the examples silently fall back on defaults.

I suppose some type of validation could catch this earlier.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
