### PR TITLE
feat: Add ignore changes on tags to `elasticbeanstalk:shared-elb-environment-count`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,12 @@ resource "aws_lb" "this" {
     update = try(var.timeouts.update, null)
     delete = try(var.timeouts.delete, null)
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags["elasticbeanstalk:shared-elb-environment-count"]
+    ]
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Add ```ignore_changes``` to ```aws_lb```.

## Motivation and Context
To avoid this situation when we have a shared ALB with ElasticBeanstalk
```  # module.alb.aws_lb.this[0] will be updated in-place
  ~ resource "aws_lb" "this" {
        id                                          = "arn:aws:elasticloadbalancing:xxx:xxxx:loadbalancer/app/shared-alb/xxx"
        name                                        = "shared-alb"
      ~ tags                                        = {
          - "elasticbeanstalk:shared-elb-environment-count" = "1" -> null
            "terraform-aws-modules"                         = "alb"
        }
      ~ tags_all                                    = {
          - "elasticbeanstalk:shared-elb-environment-count" = "1" -> null
            # (4 unchanged elements hidden)
        }
        # (21 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }```
```

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
