### PR TITLE
docs: Link from examples to patterns

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,5 @@ Please note - the examples provided serve two primary means:
 2. A means of testing/validating module changes
 
 Please do not mistake the examples provided as "best practices". It is up to users to consult the AWS service documentation for best practices, usage recommendations, etc.
+
+Additional examples of typical usage patterns are [documented here](/docs/patterns.md).


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Just add a link from [/examples/README.md](https://github.com/terraform-aws-modules/terraform-aws-alb/tree/master/examples/README.md) to [/docs/patterns.md](https://github.com/terraform-aws-modules/terraform-aws-alb/tree/master/docs/patterns.md).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For ease of finding relevant code snippets, spanning multiple documentation pages.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Tangentially relates to #311.