### PR TITLE
docs: Add multiple target groups with for loop pattern

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -317,3 +317,41 @@ module "alb" {
   }
 }
 ```
+
+### Multiple Target Groups with For Loop
+
+The configuration snippet below creates two target groups using a for loop. This is useful to provision multiple different target groups with similar configurations at scale. The for loop will iterate over the `local.services` map definition and create corresponding `target_groups` map with the same key names and associated values.
+
+```hcl
+local {
+  services = {
+    blue = {
+      path = "/"
+      port = 80
+    }
+    green = {
+      path = "/"
+      port = 80
+    }
+  }
+}
+
+module "alb" {
+  source = "terraform-aws-modules/alb/aws"
+
+  # Truncated for brevity ...
+
+  target_groups = {
+    for key, value in local.services : key => {
+      name              = key
+      port              = value.port
+      target_type       = "ip"
+      create_attachment = false
+
+      health_check = {
+        path = value.path
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Per #311, adding a new usage pattern enabling multiple target groups to be provisioned using a for loop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

By leveraging a for loop with maps, it enables provisioning-at-scale and keep code DRY.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
