### PR TITLE
fix: Add sensitive = true flag to listeners and listener_rules outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -34,11 +34,13 @@ output "zone_id" {
 output "listeners" {
   description = "Map of listeners created and their attributes"
   value       = aws_lb_listener.this
+  sensitive   = true
 }
 
 output "listener_rules" {
   description = "Map of listeners rules created and their attributes"
   value       = aws_lb_listener_rule.this
+  sensitive   = true
 }
 
 ################################################################################


### PR DESCRIPTION
## Description

allows for use of OIDC authentication in listeners without triggering:

```
╷
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 34:
│   34: output "listeners" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
```

these values are already present in the examples subdirectory.

## Motivation and Context
Fixes the ability to use OIDC authentication in listeners, without exposing tokens in outputs.

## Breaking Changes
n/a.

## How Has This Been Tested?
- [n/a] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [Y] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [Y] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
