### PR TITLE
Ignoring subnets if subnet_mapping is set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_lb" "this" {
     }
   }
 
-  subnets                    = var.subnets
+  subnets                    = length(var.subnet_mapping) == 0 ? var.subnets : null
   tags                       = local.tags
   xff_header_processing_mode = var.xff_header_processing_mode
 

--- a/variables.tf
+++ b/variables.tf
@@ -141,7 +141,7 @@ variable "security_groups" {
 }
 
 variable "subnet_mapping" {
-  description = "A list of subnet mapping blocks describing subnets to attach to load balancer"
+  description = "A list of subnet mapping blocks describing subnets to attach to load balancer. If set, var.subnets is ignored."
   type        = list(map(string))
   default     = []
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Now it does not pass var.subnets to aws_lb resource in case if var.subnet_mapping is not empty.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Received an error
```
╷
│ Error: Invalid combination of arguments
│ 
│   with module.nlb.aws_lb.this[0],
│   on .terraform/modules/nlb/main.tf line 12, in resource "aws_lb" "this":
│   12: resource "aws_lb" "this" {
│ 
│ "subnet_mapping": only one of `subnet_mapping,subnets` can be specified, but `subnet_mapping,subnets` were specified.
╵
```
Figured out, that var.subnets is always set for aws_lb resource, and there is no option to set it to null from outer level.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [ ] ~I have updated at least one of the `examples/*` to demonstrate and validate my change(s)~
- [ ] ~I have tested and validated these changes using one or more of the provided `examples/*` projects~
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] ~I have executed `pre-commit run -a` on my pull request~
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

- [x] I have applied it on my stack.
