### PR TITLE
fix: Change `subnets` default value to `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ No modules.
 | <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Determines whether the security group name (`security_group_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to assign to the LB | `list(string)` | `[]` | no |
 | <a name="input_subnet_mapping"></a> [subnet\_mapping](#input\_subnet\_mapping) | A list of subnet mapping blocks describing subnets to attach to load balancer | `list(map(string))` | `[]` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of subnet IDs to attach to the LB. Subnets cannot be updated for Load Balancers of type `network`. Changing this value for load balancers of type `network` will force a recreation of the resource | `list(string)` | `[]` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of subnet IDs to attach to the LB. Subnets cannot be updated for Load Balancers of type `network`. Changing this value for load balancers of type `network` will force a recreation of the resource | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_target_groups"></a> [target\_groups](#input\_target\_groups) | Map of target group configurations to create | `any` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the load balancer | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -149,7 +149,7 @@ variable "subnet_mapping" {
 variable "subnets" {
   description = "A list of subnet IDs to attach to the LB. Subnets cannot be updated for Load Balancers of type `network`. Changing this value for load balancers of type `network` will force a recreation of the resource"
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "xff_header_processing_mode" {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -39,7 +39,7 @@ module "wrapper" {
   security_group_use_name_prefix                               = try(each.value.security_group_use_name_prefix, var.defaults.security_group_use_name_prefix, true)
   security_groups                                              = try(each.value.security_groups, var.defaults.security_groups, [])
   subnet_mapping                                               = try(each.value.subnet_mapping, var.defaults.subnet_mapping, [])
-  subnets                                                      = try(each.value.subnets, var.defaults.subnets, [])
+  subnets                                                      = try(each.value.subnets, var.defaults.subnets, null)
   tags                                                         = try(each.value.tags, var.defaults.tags, {})
   target_groups                                                = try(each.value.target_groups, var.defaults.target_groups, {})
   timeouts                                                     = try(each.value.timeouts, var.defaults.timeouts, {})


### PR DESCRIPTION
## Description
Change default of `subnets` from `[]` to `null`.

## Motivation and Context
Fix #340.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No. As far as I know, the previous default of `subnets = []` is useless, because
 - the default will be overridden when `subnets` is provided by user, or
 - the default will be ignored when `subnet_mapping` is provided by user.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
   - No change to examples were needed.
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
   - Tested with the code in #340.
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
