### PR TITLE
feat: Additional target group attachments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.5
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
@@ -28,3 +28,4 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ No modules.
 | [aws_lb_listener_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
 | [aws_lb_listener_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group_attachment.additional_target_group_attachments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
+| [aws_lb_target_group_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -385,7 +385,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | Map containing access logging configuration for load balancer | `map(string)` | `{}` | no |
-| <a name="input_additional_target_group_attachments"></a> [additional\_target\_group\_attachments](#input\_additional\_target\_group\_attachments) | Map of additional target group attchments to create | `any` | `{}` | no |
+| <a name="input_additional_target_group_attachments"></a> [additional\_target\_group\_attachments](#input\_additional\_target\_group\_attachments) | Map of additional target group attachments to create. Use `target_group_key` to attach to the target group created in `target_groups` | `any` | `{}` | no |
 | <a name="input_associate_web_acl"></a> [associate\_web\_acl](#input\_associate\_web\_acl) | Indicates whether a Web Application Firewall (WAF) ACL should be associated with the load balancer | `bool` | `false` | no |
 | <a name="input_connection_logs"></a> [connection\_logs](#input\_connection\_logs) | Map containing access logging configuration for load balancer | `map(string)` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects nearly all resources) | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ No modules.
 | [aws_lb_listener_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
 | [aws_lb_listener_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group_attachment.additional_target_group_attachments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -384,6 +385,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | Map containing access logging configuration for load balancer | `map(string)` | `{}` | no |
+| <a name="input_additional_target_group_attachments"></a> [additional\_target\_group\_attachments](#input\_additional\_target\_group\_attachments) | Map of additional target group attchments to create | `any` | `{}` | no |
 | <a name="input_associate_web_acl"></a> [associate\_web\_acl](#input\_associate\_web\_acl) | Indicates whether a Web Application Firewall (WAF) ACL should be associated with the load balancer | `bool` | `false` | no |
 | <a name="input_connection_logs"></a> [connection\_logs](#input\_connection\_logs) | Map containing access logging configuration for load balancer | `map(string)` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects nearly all resources) | `bool` | `true` | no |

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -18,9 +18,9 @@ If you found a bug, please open an issue in this repository.
     - aws_lb_listener.frontend_http_tcp_no_logs
     - aws_lb_listener.frontend_https_no_logs
     - aws_lb_listener_certificate.https_listener_no_logs
-  
+
    If you've been using ALB without access logs enabled then you need to run `terraform state mv` to rename resources to new names:
-  
+
     - aws_lb.this
     - aws_lb_target_group.main
     - aws_lb_listener.frontend_http_tcp
@@ -28,7 +28,7 @@ If you found a bug, please open an issue in this repository.
     - aws_lb_listener_certificate.https_listener
 
    For example, this command will rename ALB resource: `terraform state mv aws_lb.application_no_logs aws_lb.this`
-  
+
 2. Removed variable `target_groups_count`, `http_tcp_listeners_count`, `extra_ssl_certs_count`, `http_tcp_listeners_count`.
 
 3. Removed variable `target_groups_defaults`. Instead, all `health_check` and `stickiness` settings should be implicit for each target group.

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -50,6 +50,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_cognito_user_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
 | [aws_cognito_user_pool_client.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client) | resource |
 | [aws_cognito_user_pool_domain.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_domain) | resource |
+| [aws_instance.other](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -398,6 +398,15 @@ module "alb" {
     }
   }
 
+  additional_target_group_attachments = {
+    ex-instance-other = {
+      target_group = "ex-instance"
+      target_type  = "instance"
+      target_id    = aws_instance.other.id
+      port         = "80"
+    }
+  }
+
   # Route53 Record(s)
   route53_records = {
     A = {
@@ -525,6 +534,12 @@ data "aws_ssm_parameter" "al2" {
 }
 
 resource "aws_instance" "this" {
+  ami           = data.aws_ssm_parameter.al2.value
+  instance_type = "t3.nano"
+  subnet_id     = element(module.vpc.private_subnets, 0)
+}
+
+resource "aws_instance" "other" {
   ami           = data.aws_ssm_parameter.al2.value
   instance_type = "t3.nano"
   subnet_id     = element(module.vpc.private_subnets, 0)

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -400,10 +400,10 @@ module "alb" {
 
   additional_target_group_attachments = {
     ex-instance-other = {
-      target_group = "ex-instance"
-      target_type  = "instance"
-      target_id    = aws_instance.other.id
-      port         = "80"
+      target_group_key = "ex-instance"
+      target_type      = "instance"
+      target_id        = aws_instance.other.id
+      port             = "80"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -541,6 +541,17 @@ resource "aws_lb_target_group_attachment" "this" {
   depends_on = [aws_lambda_permission.this]
 }
 
+resource "aws_lb_target_group_attachment" "additional_target_group_attachments" {
+  for_each = { for k, v in var.additional_target_group_attachments : k => v if local.create }
+
+  target_group_arn  = aws_lb_target_group.this[each.value.target_group].arn
+  target_id         = each.value.target_id
+  port              = try(each.value.target_type, null) == "lambda" ? null : try(each.value.port, var.default_port)
+  availability_zone = try(each.value.availability_zone, null)
+
+  depends_on = [aws_lambda_permission.this]
+}
+
 ################################################################################
 # Lambda Permission
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -541,10 +541,10 @@ resource "aws_lb_target_group_attachment" "this" {
   depends_on = [aws_lambda_permission.this]
 }
 
-resource "aws_lb_target_group_attachment" "additional_target_group_attachments" {
+resource "aws_lb_target_group_attachment" "additional" {
   for_each = { for k, v in var.additional_target_group_attachments : k => v if local.create }
 
-  target_group_arn  = aws_lb_target_group.this[each.value.target_group].arn
+  target_group_arn  = aws_lb_target_group.this[each.value.target_group_key].arn
   target_id         = each.value.target_id
   port              = try(each.value.target_type, null) == "lambda" ? null : try(each.value.port, var.default_port)
   availability_zone = try(each.value.availability_zone, null)

--- a/variables.tf
+++ b/variables.tf
@@ -197,7 +197,7 @@ variable "target_groups" {
 }
 
 variable "additional_target_group_attachments" {
-  description = "Map of additional target group attchments to create"
+  description = "Map of additional target group attachments to create. Use `target_group_key` to attach to the target group created in `target_groups`"
   type        = any
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -196,6 +196,12 @@ variable "target_groups" {
   default     = {}
 }
 
+variable "additional_target_group_attachments" {
+  description = "Map of additional target group attchments to create"
+  type        = any
+  default     = {}
+}
+
 ################################################################################
 # Security Group
 ################################################################################

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -4,6 +4,7 @@ module "wrapper" {
   for_each = var.items
 
   access_logs                                                  = try(each.value.access_logs, var.defaults.access_logs, {})
+  additional_target_group_attachments                          = try(each.value.additional_target_group_attachments, var.defaults.additional_target_group_attachments, {})
   associate_web_acl                                            = try(each.value.associate_web_acl, var.defaults.associate_web_acl, false)
   connection_logs                                              = try(each.value.connection_logs, var.defaults.connection_logs, {})
   create                                                       = try(each.value.create, var.defaults.create, true)


### PR DESCRIPTION
## Description
This adds a variable `additional_target_group_attachments` for specifying additional attachments for target groups.

## Motivation and Context
 This is particularly useful when the only handle you have to an instance is its IP address, and you need to provide multiple IPs to a target group.

Resolves #316

## Breaking Changes
This does not break backwards compatibility.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - I deployed the examples/complete-alb without my changes, and then with my changes. The target group `ex-instance` successfully deploys with an additional target, `aws_instance.other`
- [x] I have executed `pre-commit run -a` on my pull request
