### PR TITLE
feat: Disable route53 record creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -650,7 +650,7 @@ resource "aws_vpc_security_group_ingress_rule" "this" {
 ################################################################################
 
 resource "aws_route53_record" "this" {
-  for_each = { for k, v in var.route53_records : k => v if var.create }
+  for_each = var.create && var.create_route53_records ? var.route53_records : {}
 
   zone_id = each.value.zone_id
   name    = try(each.value.name, each.key)

--- a/variables.tf
+++ b/variables.tf
@@ -258,6 +258,12 @@ variable "security_group_tags" {
 # Route53 Record(s)
 ################################################################################
 
+variable "create_route53_records" {
+  description = "Determines whether or not to create Route53 'A' and 'AAAA' records for the loadbalancer."
+  type        = bool
+  default     = true
+}
+
 variable "route53_records" {
   description = "Map of Route53 records to create. Each record map should contain `zone_id`, `name`, and `type`"
   type        = any


### PR DESCRIPTION
## Description
I adjusted the way resource "aws_route53_record" "this" handles variables so that I can avoid creating route53 records that were not needed. I use private dns and certs and this was causing some issues and unneeded route53 records. 

## How Has This Been Tested?
I made this change locally and deployed it into my production environment., 
