### PR TITLE
feat: Add `target_group_health` block

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,13 +352,13 @@ See [patterns.md](https://github.com/terraform-aws-modules/terraform-aws-alb/blo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
 
 ## Modules
 

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -20,15 +20,17 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 
 ## Modules
 
@@ -53,6 +55,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_instance.other](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_ssm_parameter.al2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -370,11 +370,9 @@ module "alb" {
 
       target_group_health = {
         dns_failover = {
-          minimum_healthy_targets_count      = 1
-          minimum_healthy_targets_percentage = 50
+          minimum_healthy_targets_count = 2
         }
         unhealthy_state_routing = {
-          minimum_healthy_targets_count      = 1
           minimum_healthy_targets_percentage = 50
         }
       }

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -368,6 +368,17 @@ module "alb" {
       load_balancing_anomaly_mitigation = "on"
       load_balancing_cross_zone_enabled = false
 
+      target_group_health = {
+        dns_failover = {
+          minimum_healthy_targets_count      = 1
+          minimum_healthy_targets_percentage = 50
+        }
+        unhealthy_state_routing = {
+          minimum_healthy_targets_count      = 1
+          minimum_healthy_targets_percentage = 50
+        }
+      }
+
       health_check = {
         enabled             = true
         interval            = 30
@@ -568,8 +579,14 @@ resource "aws_cognito_user_pool_client" "this" {
   allowed_oauth_flows_user_pool_client = true
 }
 
+resource "random_string" "this" {
+  length  = 5
+  upper   = false
+  special = false
+}
+
 resource "aws_cognito_user_pool_domain" "this" {
-  domain       = local.name
+  domain       = "${local.name}-${random_string.this.result}"
   user_pool_id = aws_cognito_user_pool.this.id
 }
 

--- a/examples/complete-alb/versions.tf
+++ b/examples/complete-alb/versions.tf
@@ -4,11 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.59"
     }
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
     }
   }
 }

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
 
 ## Modules
 

--- a/examples/complete-nlb/versions.tf
+++ b/examples/complete-nlb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.59"
     }
   }
 }

--- a/examples/mutual-auth-alb/README.md
+++ b/examples/mutual-auth-alb/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
@@ -29,7 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 

--- a/examples/mutual-auth-alb/versions.tf
+++ b/examples/mutual-auth-alb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.59"
     }
     null = {
       source  = "hashicorp/null"

--- a/main.tf
+++ b/main.tf
@@ -540,6 +540,31 @@ resource "aws_lb_target_group" "this" {
     }
   }
 
+  dynamic "target_group_health" {
+    for_each = try([each.value.target_group_health], [])
+
+    content {
+
+      dynamic "dns_failover" {
+        for_each = try([target_group_health.value.dns_failover], [])
+
+        content {
+          minimum_healthy_targets_count      = try(dns_failover.value.minimum_healthy_targets_count, null)
+          minimum_healthy_targets_percentage = try(dns_failover.value.minimum_healthy_targets_percentage, null)
+        }
+      }
+
+      dynamic "unhealthy_state_routing" {
+        for_each = try([target_group_health.value.unhealthy_state_routing], [])
+
+        content {
+          minimum_healthy_targets_count      = try(unhealthy_state_routing.value.minimum_healthy_targets_count, null)
+          minimum_healthy_targets_percentage = try(unhealthy_state_routing.value.minimum_healthy_targets_percentage, null)
+        }
+      }
+    }
+  }
+
   dynamic "target_health_state" {
     for_each = try([each.value.target_health_state], [])
     content {

--- a/modules/lb_trust_store/README.md
+++ b/modules/lb_trust_store/README.md
@@ -30,13 +30,13 @@ module "trust_store" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
 
 ## Modules
 

--- a/modules/lb_trust_store/versions.tf
+++ b/modules/lb_trust_store/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.59"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.59"
     }
   }
 }


### PR DESCRIPTION
## Description
Add support for `target_group_health` block.
Added random string to `aws_cognito_user_pool_domain` `domain` since they must be unique across all accounts and regions otherwise `Domain already associated with another user pool.` error is provided. 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/37082

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
