### PR TITLE
Remove opinionated tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@ data "aws_partition" "current" {}
 
 locals {
   create = var.create && var.putin_khuylo
-  tags   = merge(var.tags, { terraform-aws-modules = "alb" })
 }
 
 ################################################################################
@@ -64,7 +63,7 @@ resource "aws_lb" "this" {
   }
 
   subnets                    = var.subnets
-  tags                       = local.tags
+  tags                       = var.tags
   xff_header_processing_mode = var.xff_header_processing_mode
 
   timeouts {
@@ -219,7 +218,7 @@ resource "aws_lb_listener" "this" {
   port              = try(each.value.port, var.default_port)
   protocol          = try(each.value.protocol, var.default_protocol)
   ssl_policy        = contains(["HTTPS", "TLS"], try(each.value.protocol, var.default_protocol)) ? try(each.value.ssl_policy, "ELBSecurityPolicy-TLS13-1-2-Res-2021-06") : try(each.value.ssl_policy, null)
-  tags              = merge(local.tags, try(each.value.tags, {}))
+  tags              = try(each.value.tags, {})
 }
 
 ################################################################################
@@ -446,7 +445,7 @@ resource "aws_lb_listener_rule" "this" {
     }
   }
 
-  tags = merge(local.tags, try(each.value.tags, {}))
+  tags = try(each.value.tags, {})
 }
 
 ################################################################################
@@ -576,7 +575,7 @@ resource "aws_lb_target_group" "this" {
   target_type = try(each.value.target_type, null)
   vpc_id      = try(each.value.vpc_id, var.vpc_id)
 
-  tags = merge(local.tags, try(each.value.tags, {}))
+  tags = try(each.value.tags, {})
 
   lifecycle {
     create_before_destroy = true
@@ -657,7 +656,7 @@ resource "aws_security_group" "this" {
   description = coalesce(var.security_group_description, "Security group for ${local.security_group_name} ${var.load_balancer_type} load balancer")
   vpc_id      = var.vpc_id
 
-  tags = merge(local.tags, var.security_group_tags)
+  tags = var.security_group_tags
 
   lifecycle {
     create_before_destroy = true
@@ -680,7 +679,7 @@ resource "aws_vpc_security_group_egress_rule" "this" {
   referenced_security_group_id = lookup(each.value, "referenced_security_group_id", null)
   to_port                      = try(each.value.to_port, null)
 
-  tags = merge(local.tags, var.security_group_tags, try(each.value.tags, {}))
+  tags = merge(var.security_group_tags, try(each.value.tags, {}))
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this" {
@@ -699,7 +698,7 @@ resource "aws_vpc_security_group_ingress_rule" "this" {
   referenced_security_group_id = lookup(each.value, "referenced_security_group_id", null)
   to_port                      = try(each.value.to_port, null)
 
-  tags = merge(local.tags, var.security_group_tags, try(each.value.tags, {}))
+  tags = merge(var.security_group_tags, try(each.value.tags, {}))
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
This PR is removing the opinionated tag residing in locals.tags `tags   = merge(var.tags, { terraform-aws-modules = "alb" })`

## Motivation and Context
This goes against expected and predictable behaviour, and can also not be removed or overwritten. Thus is should not exist at all, and give the users the option to add it if needed.

Looking at other terraform-aws-modules, I haven't seen any others doing this?

## Breaking Changes
Should not cause any breaking changes. It should also not trigger resource recreation as this is impacting tags only.

May present an inconvenience to people that had this tag passively added to their resources, and made use of it in other areas of AWS (reporting, costing etc)
