### PR TITLE
fix: to allow multiple query strings

### DIFF
--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -137,10 +137,14 @@ module "alb" {
           }]
 
           conditions = [{
-            query_string = {
+            query_string = [{
               key   = "video"
               value = "random"
-            }
+              },
+              {
+                key   = "image"
+                value = "next"
+            }]
           }]
         }
       }

--- a/main.tf
+++ b/main.tf
@@ -422,7 +422,7 @@ resource "aws_lb_listener_rule" "this" {
 
     content {
       dynamic "query_string" {
-        for_each = try([condition.value.query_string], [])
+        for_each = try(flatten([condition.value.query_string]), [])
 
         content {
           key   = try(query_string.value.key, null)


### PR DESCRIPTION
## Description
Fix to allow you to pass multiple query string to load balancer rule

## Motivation and Context
We needed to add 2 conditions are the current module did not support it

## Breaking Changes
No

## How Has This Been Tested?
- [ X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ X] I have executed `pre-commit run -a` on my pull request
