### PR TITLE
feat: to allow support for prevent_destroy lifecycle option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ resource "aws_lb" "this" {
     ignore_changes = [
       tags["elasticbeanstalk:shared-elb-environment-count"]
     ]
+    prevent_destroy = var.enable_alb_prevent_destroy
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,12 @@ variable "timeouts" {
   default     = {}
 }
 
+variable "enable_alb_prevent_destroy" {
+  description = "Whether to add lifecycle.prevent_destroy to the ALB resource"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Listener(s)
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Many users wish to prevent accidental destruction of their Application Load Balancers, especially when load balancers are shared or provisioned for longer-lived environments (e.g., shared Route53 records or multi-app balancers). I found this useful when creating feature branch environment where environments are short lived and often destroyed using `terraform destroy` but we don't want to destroy the ALBs as they are shared across applications and feature branches.

Terraform’s lifecycle block supports prevent_destroy, but the current module does not expose this as an option.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ - ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
