### PR TITLE
docs: Update the complete-alb example to apply without errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.100.0
+    rev: v1.100.1
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/examples/complete-alb/main.tf
+++ b/examples/complete-alb/main.tf
@@ -104,12 +104,12 @@ module "alb" {
             weighted_forward = {
               target_groups = [
                 {
-                  key    = "ex-lambda-with-trigger"
-                  weight = 2
+                  target_group_key = "ex-lambda-with-trigger"
+                  weight           = 2
                 },
                 {
-                  key    = "ex-instance"
-                  weight = 1
+                  target_group_key = "ex-instance"
+                  weight           = 1
                 }
               ]
               stickiness = {
@@ -259,15 +259,19 @@ module "alb" {
             }
           }]
 
-          conditions = [{
-            query_string = [{
-              key   = "weighted"
-              value = "true"
-            }],
-            path_pattern = {
-              values = ["/some/path"]
-            }
-          }]
+          conditions = [
+            {
+              query_string = [{
+                key   = "weighted"
+                value = "true"
+              }]
+            },
+            {
+              path_pattern = {
+                values = ["/some/path"]
+              }
+            },
+          ]
         }
 
         ex-redirect = {


### PR DESCRIPTION
## Description
The complete-alb example needs a few fixes to apply without errors.

## Motivation and Context
`terraform apply` returns a warning and some errors:
```
╷
│ Warning: Invalid Attribute Combination
│ 
│   with module.alb.aws_lb_target_group.this["ex-lambda-with-trigger"],
│   on ../../main.tf line 578, in resource "aws_lb_target_group" "this":
│  578:   port                               = each.value.target_type == "lambda" ? null : coalesce(each.value.port, var.default_port)
│ 
│ Attribute "port" cannot be specified when "target_type" is "lambda".
│ 
│ This will be an error in a future release.
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Error: Missing required argument
│ 
│   with module.alb.aws_lb_listener_rule.this["ex-http-https-redirect/ex-weighted-forward"],
│   on ../../main.tf line 299, in resource "aws_lb_listener_rule" "this":
│  299: resource "aws_lb_listener_rule" "this" {
│ 
│ The argument "action.0.forward.0.target_group.0.arn" is required, but no
│ definition was found.
╵
╷
│ Error: Missing required argument
│ 
│   with module.alb.aws_lb_listener_rule.this["ex-http-https-redirect/ex-weighted-forward"],
│   on ../../main.tf line 299, in resource "aws_lb_listener_rule" "this":
│  299: resource "aws_lb_listener_rule" "this" {
│ 
│ The argument "action.0.forward.0.target_group.1.arn" is required, but no
│ definition was found.
╵
╷
│ Error: Only one of host_header, http_header, http_request_method, path_pattern, query_string or source_ip can be set in a condition block
│ 
│   with module.alb.aws_lb_listener_rule.this["ex-https/ex-weighted-forward"],
│   on ../../main.tf line 299, in resource "aws_lb_listener_rule" "this":
│  299: resource "aws_lb_listener_rule" "this" {
│ 
```

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
