### PR TITLE
fix: Update port and protocol handling for GENEVE in aws_lb_listener

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -273,8 +273,8 @@ resource "aws_lb_listener" "this" {
     }
   }
 
-  port                                                                  = contains(["GENEVE"], coalesce(each.value.protocol, var.default_protocol)) ? null : coalesce(each.value.port, var.default_port)
-  protocol                                                              = contains(["GENEVE"], coalesce(each.value.protocol, var.default_protocol)) ? null : coalesce(each.value.protocol, var.default_protocol)
+  port                                                                  = coalesce(each.value.protocol, var.default_protocol) != "GENEVE" ? coalesce(each.value.port, var.default_port) : null
+  protocol                                                              = coalesce(each.value.protocol, var.default_protocol) != "GENEVE" ? coalesce(each.value.protocol, var.default_protocol) : null
   routing_http_request_x_amzn_mtls_clientcert_header_name               = coalesce(each.value.protocol, var.default_protocol) == "HTTPS" ? each.value.routing_http_request_x_amzn_mtls_clientcert_header_name : null
   routing_http_request_x_amzn_mtls_clientcert_issuer_header_name        = coalesce(each.value.protocol, var.default_protocol) == "HTTPS" ? each.value.routing_http_request_x_amzn_mtls_clientcert_issuer_header_name : null
   routing_http_request_x_amzn_mtls_clientcert_leaf_header_name          = coalesce(each.value.protocol, var.default_protocol) == "HTTPS" ? each.value.routing_http_request_x_amzn_mtls_clientcert_leaf_header_name : null


### PR DESCRIPTION
## Description
`aws_lb_listener` now drop port and protocol when the resolved listener protocol is `GENEVE,` matching Gateway Load Balancer expectations.

## Motivation and Context
- Previous behaviour forced explicit values for port/protocol, which fails for GWLB listeners that must omit them.

```
│ Error: creating ELBv2 Listener (arn:aws:elasticloadbalancing:us-east-1:111111111111111:loadbalancer/gwy/my-gwlb-LGwJla8P/0ac3a7b141f63121): operation error Elastic Load Balancing v2: CreateListener, https response error StatusCode: 400, RequestID: 5b0cfb9b-e361-4826-971e-241a73712909, api error ValidationError: A protocol cannot be specified for gateway listeners
│ 
│   with module.example.module.loadbalancer.aws_lb_listener.this["geneve"],
│   on .terraform/modules/example.loadbalancer/terraform-aws-alb-10.3.0/main.tf line 116, in resource "aws_lb_listener" "this":
│  116: resource "aws_lb_listener" "this" {
│ 
```

```
│ Error: creating ELBv2 Listener (arn:aws:elasticloadbalancing:us-east-1:111111111111111:loadbalancer/gwy/my-gwlb-LGwJla8P/0ac3a7b141f63121): operation error Elastic Load Balancing v2: CreateListener, https response error StatusCode: 400, RequestID: 792e8f9e-2c83-461f-91ba-678d6db8eedf, api error ValidationError: A port cannot be specified for gateway listeners
│ 
│   with module.example.module.loadbalancer.aws_lb_listener.this["geneve"],
│   on .terraform/modules/example.loadbalancer/terraform-aws-alb-10.3.0/main.tf line 116, in resource "aws_lb_listener" "this":
│  116: resource "aws_lb_listener" "this" {
```

Setting it `null` resulted into
```
│ Error: Error in function call
│ 
│   on .terraform/modules/example.loadbalancer/terraform-aws-alb-10.3.0/main.tf line 276, in resource "aws_lb_listener" "this":
│  276:   port                                                                  = coalesce(each.value.port, var.default_port)
│     ├────────────────
│     │ while calling coalesce(vals...)
│     │ each.value.port is null
│     │ var.default_port is null
│ 
│ Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

## Breaking Changes
- None; non-GENEVE listeners behave exactly as before.

## How Has This Been Tested?
- Successful ALB/NLB deployment with/without the fix
- Successful ALB/NLB drift detection with/without the fix (no changes) to ensure no breaking changes
- Successful GWLB deployment with the fixed TF module

