### PR TITLE
fix: Allow null value for aws_lb_target_group_attachment port 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -763,7 +763,7 @@ resource "aws_lb_target_group_attachment" "this" {
 
   target_group_arn  = aws_lb_target_group.this[each.key].arn
   target_id         = each.value.target_id
-  port              = each.value.target_type == "lambda" ? null : coalesce(each.value.port, var.default_port)
+  port              = each.value.target_type == "lambda" ? null : try(each.value.port, var.default_port)
   availability_zone = each.value.availability_zone
 
   depends_on = [aws_lambda_permission.this]
@@ -776,7 +776,7 @@ resource "aws_lb_target_group_attachment" "additional" {
 
   target_group_arn  = aws_lb_target_group.this[each.value.target_group_key].arn
   target_id         = each.value.target_id
-  port              = each.value.target_type == "lambda" ? null : coalesce(each.value.port, var.default_port)
+  port              = each.value.target_type == "lambda" ? null : try(each.value.port, var.default_port)
   availability_zone = each.value.availability_zone
 
   depends_on = [aws_lambda_permission.this]


### PR DESCRIPTION
## Description
Vanilla _aws_lb_target_group_attachment_ resource allows to **not** specify a port.

## Motivation and Context
The change allows to import resources created before with no port (created with old module versions).
Usage of coalesce pushes to **re-create** existing resources and it is a pain for me.

You had a try function in version **v9.x** but did change to coalesce for some reason. Please return it back.

## Breaking Changes
It should not break anything and will work in the same way as v9.x version
