### PR TITLE
feat: Add provider meta user-agent, replacing static tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.104.0
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -357,13 +357,13 @@ See [patterns.md](https://github.com/terraform-aws-modules/terraform-aws-alb/blo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.25 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.25 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -357,13 +357,13 @@ See [patterns.md](https://github.com/terraform-aws-modules/terraform-aws-alb/blo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 
 ## Modules
 

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 

--- a/examples/complete-alb/README.md
+++ b/examples/complete-alb/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.25 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.25 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 

--- a/examples/complete-alb/versions.tf
+++ b/examples/complete-alb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.27"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/complete-alb/versions.tf
+++ b/examples/complete-alb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.25 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.25 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
 
 ## Modules
 

--- a/examples/complete-nlb/README.md
+++ b/examples/complete-nlb/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 
 ## Modules
 

--- a/examples/complete-nlb/versions.tf
+++ b/examples/complete-nlb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 }

--- a/examples/complete-nlb/versions.tf
+++ b/examples/complete-nlb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.27"
     }
   }
 }

--- a/examples/mutual-auth-alb/README.md
+++ b/examples/mutual-auth-alb/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.25 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
@@ -29,7 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.25 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 

--- a/examples/mutual-auth-alb/README.md
+++ b/examples/mutual-auth-alb/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
@@ -29,7 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 

--- a/examples/mutual-auth-alb/versions.tf
+++ b/examples/mutual-auth-alb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.27"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/mutual-auth-alb/versions.tf
+++ b/examples/mutual-auth-alb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
     null = {
       source  = "hashicorp/null"

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,6 @@ data "aws_partition" "current" {
 
 locals {
   create = var.create && var.putin_khuylo
-  tags   = merge(var.tags, { terraform-aws-modules = "alb" })
 }
 
 ################################################################################
@@ -98,7 +97,7 @@ resource "aws_lb" "this" {
   }
 
   subnets                    = var.subnets
-  tags                       = local.tags
+  tags                       = var.tags
   xff_header_processing_mode = var.xff_header_processing_mode
 
   dynamic "timeouts" {
@@ -307,7 +306,7 @@ resource "aws_lb_listener" "this" {
   tcp_idle_timeout_seconds                                              = coalesce(each.value.protocol, var.default_protocol) == "TCP" ? each.value.tcp_idle_timeout_seconds : null
 
   tags = merge(
-    local.tags,
+    var.tags,
     each.value.tags,
   )
 }
@@ -606,7 +605,7 @@ resource "aws_lb_listener_rule" "this" {
   }
 
   tags = merge(
-    local.tags,
+    var.tags,
     each.value.tags,
   )
 }
@@ -743,7 +742,7 @@ resource "aws_lb_target_group" "this" {
   vpc_id      = coalesce(each.value.vpc_id, var.vpc_id)
 
   tags = merge(
-    local.tags,
+    var.tags,
     each.value.tags,
   )
 
@@ -834,7 +833,7 @@ resource "aws_security_group" "this" {
   description = coalesce(var.security_group_description, "Security group for ${local.security_group_name} ${var.load_balancer_type} load balancer")
   vpc_id      = var.vpc_id
 
-  tags = merge(local.tags, var.security_group_tags)
+  tags = merge(var.tags, var.security_group_tags)
 
   lifecycle {
     create_before_destroy = true

--- a/modules/lb_trust_store/README.md
+++ b/modules/lb_trust_store/README.md
@@ -30,13 +30,13 @@ module "trust_store" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 
 ## Modules
 

--- a/modules/lb_trust_store/README.md
+++ b/modules/lb_trust_store/README.md
@@ -30,13 +30,13 @@ module "trust_store" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.25 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.25 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
 
 ## Modules
 

--- a/modules/lb_trust_store/versions.tf
+++ b/modules/lb_trust_store/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 
   provider_meta "aws" {
     user_agent = [
-      "github.com/terraform-aws-modules"
+      "github.com/terraform-aws-modules/terraform-aws-alb"
     ]
   }
 }

--- a/modules/lb_trust_store/versions.tf
+++ b/modules/lb_trust_store/versions.tf
@@ -4,7 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.27"
     }
+  }
+
+  provider_meta "aws" {
+    user_agent = [
+      "github.com/terraform-aws-modules"
+    ]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 
   provider_meta "aws" {
     user_agent = [
-      "github.com/terraform-aws-modules"
+      "github.com/terraform-aws-modules/terraform-aws-alb"
     ]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.27"
     }
+  }
+
+  provider_meta "aws" {
+    user_agent = [
+      "github.com/terraform-aws-modules"
+    ]
   }
 }

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -70,9 +70,9 @@ module "wrapper" {
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
+  source = "tfr:///terraform-aws-modules/alb/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git//wrappers?ref=master"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-alb.git//wrappers?ref=master"
 }
 
 inputs = {

--- a/wrappers/lb_trust_store/README.md
+++ b/wrappers/lb_trust_store/README.md
@@ -70,9 +70,9 @@ module "wrapper" {
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
+  source = "tfr:///terraform-aws-modules/alb/aws//wrappers/lb_trust_store"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git//wrappers?ref=master"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-alb.git//wrappers/lb_trust_store?ref=master"
 }
 
 inputs = {

--- a/wrappers/lb_trust_store/versions.tf
+++ b/wrappers/lb_trust_store/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 
   provider_meta "aws" {
     user_agent = [
-      "github.com/terraform-aws-modules"
+      "github.com/terraform-aws-modules/terraform-aws-alb"
     ]
   }
 }

--- a/wrappers/lb_trust_store/versions.tf
+++ b/wrappers/lb_trust_store/versions.tf
@@ -4,7 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.27"
     }
+  }
+
+  provider_meta "aws" {
+    user_agent = [
+      "github.com/terraform-aws-modules"
+    ]
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 
   provider_meta "aws" {
     user_agent = [
-      "github.com/terraform-aws-modules"
+      "github.com/terraform-aws-modules/terraform-aws-alb"
     ]
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.27"
     }
+  }
+
+  provider_meta "aws" {
+    user_agent = [
+      "github.com/terraform-aws-modules"
+    ]
   }
 }


### PR DESCRIPTION
## Description
- Add provider meta user-agent, replacing static tag

## Motivation and Context
- Attribution to our modules can now be collected through normal means by adding to the user-agent used in API requests https://github.com/hashicorp/terraform-provider-aws/pull/45464 - we no longer need the static tags

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
